### PR TITLE
Add placeholder screens for create team, tournaments, and profile

### DIFF
--- a/football-app/src/screens/CreateTeamScreen.tsx
+++ b/football-app/src/screens/CreateTeamScreen.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { View, Text, Button } from 'react-native';
+import { NativeStackScreenProps } from '@react-navigation/native-stack';
+
+type CreateTeamStackParamList = {
+  'Create Team': undefined;
+};
+
+type CreateTeamScreenProps = NativeStackScreenProps<CreateTeamStackParamList, 'Create Team'>;
+
+const CreateTeamScreen: React.FC<CreateTeamScreenProps> = ({ navigation }) => {
+  return (
+    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+      <Text>Create a new team coming soon!</Text>
+      <Button title="Go Back" onPress={() => navigation.goBack()} />
+    </View>
+  );
+};
+
+export default CreateTeamScreen;

--- a/football-app/src/screens/ProfileScreen.tsx
+++ b/football-app/src/screens/ProfileScreen.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { View, Text, Button } from 'react-native';
+import { NativeStackScreenProps } from '@react-navigation/native-stack';
+
+type ProfileStackParamList = {
+  Profile: undefined;
+};
+
+type ProfileScreenProps = NativeStackScreenProps<ProfileStackParamList, 'Profile'>;
+
+const ProfileScreen: React.FC<ProfileScreenProps> = ({ navigation }) => {
+  return (
+    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+      <Text>Your profile details will go here!</Text>
+      <Button title="Go Back" onPress={() => navigation.goBack()} />
+    </View>
+  );
+};
+
+export default ProfileScreen;

--- a/football-app/src/screens/TournamentScreen.tsx
+++ b/football-app/src/screens/TournamentScreen.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { View, Text, Button } from 'react-native';
+import { NativeStackScreenProps } from '@react-navigation/native-stack';
+
+type TournamentStackParamList = {
+  Tournaments: undefined;
+};
+
+type TournamentScreenProps = NativeStackScreenProps<TournamentStackParamList, 'Tournaments'>;
+
+const TournamentScreen: React.FC<TournamentScreenProps> = ({ navigation }) => {
+  return (
+    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+      <Text>Tournament listings will appear here!</Text>
+      <Button title="Go Back" onPress={() => navigation.goBack()} />
+    </View>
+  );
+};
+
+export default TournamentScreen;


### PR DESCRIPTION
## Summary
- add scaffolded Create Team screen with typed navigation and a placeholder go-back action
- add Tournament screen and Profile screen scaffolds with typed navigation props for future flows

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e1883fa668832e970a9d9f64390803