### PR TITLE
Fix HomeScreen navigation route names

### DIFF
--- a/football-app/src/screens/HomeScreen.tsx
+++ b/football-app/src/screens/HomeScreen.tsx
@@ -1,25 +1,32 @@
 import React from 'react';
 import { View, Text, Button } from 'react-native';
 
+const ROUTES = {
+    TEAM: 'Team',
+    CREATE_TEAM: 'Create Team',
+    TOURNAMENTS: 'Tournaments',
+    PROFILE: 'Profile',
+} as const;
+
 const HomeScreen = ({ navigation }) => {
     return (
         <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
             <Text>Welcome to the Football App!</Text>
             <Button
                 title="Manage Teams"
-                onPress={() => navigation.navigate('TeamScreen')}
+                onPress={() => navigation.navigate(ROUTES.TEAM)}
             />
             <Button
                 title="Create a Team"
-                onPress={() => navigation.navigate('CreateTeamScreen')}
+                onPress={() => navigation.navigate(ROUTES.CREATE_TEAM)}
             />
             <Button
                 title="Join Tournaments"
-                onPress={() => navigation.navigate('TournamentScreen')}
+                onPress={() => navigation.navigate(ROUTES.TOURNAMENTS)}
             />
             <Button
                 title="Profile"
-                onPress={() => navigation.navigate('ProfileScreen')}
+                onPress={() => navigation.navigate(ROUTES.PROFILE)}
             />
         </View>
     );


### PR DESCRIPTION
## Summary
- align Home screen navigation targets with the registered stack screen names
- centralize route identifiers in a ROUTES constant for future reuse

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e188435fbc832e8c9131259d82d677