### PR TITLE
Add Redux store setup and team card component

### DIFF
--- a/football-app/src/App.tsx
+++ b/football-app/src/App.tsx
@@ -1,25 +1,29 @@
 import React from 'react';
 import { NavigationContainer } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { Provider } from 'react-redux';
 import HomeScreen from './screens/HomeScreen';
 import TeamScreen from './screens/TeamScreen';
 import CreateTeamScreen from './screens/CreateTeamScreen';
 import TournamentScreen from './screens/TournamentScreen';
 import ProfileScreen from './screens/ProfileScreen';
+import { store } from './store';
 
 const Stack = createNativeStackNavigator();
 
 const App = () => {
   return (
-    <NavigationContainer>
-      <Stack.Navigator initialRouteName="Home">
-        <Stack.Screen name="Home" component={HomeScreen} />
-        <Stack.Screen name="Team" component={TeamScreen} />
-        <Stack.Screen name="Create Team" component={CreateTeamScreen} />
-        <Stack.Screen name="Tournaments" component={TournamentScreen} />
-        <Stack.Screen name="Profile" component={ProfileScreen} />
-      </Stack.Navigator>
-    </NavigationContainer>
+    <Provider store={store}>
+      <NavigationContainer>
+        <Stack.Navigator initialRouteName="Home">
+          <Stack.Screen name="Home" component={HomeScreen} />
+          <Stack.Screen name="Team" component={TeamScreen} />
+          <Stack.Screen name="Create Team" component={CreateTeamScreen} />
+          <Stack.Screen name="Tournaments" component={TournamentScreen} />
+          <Stack.Screen name="Profile" component={ProfileScreen} />
+        </Stack.Navigator>
+      </NavigationContainer>
+    </Provider>
   );
 };
 

--- a/football-app/src/components/TeamCard.tsx
+++ b/football-app/src/components/TeamCard.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { Team } from '../store/slices/teamsSlice';
+
+type TeamCardProps = {
+  team: Team;
+  onRemove: () => void;
+};
+
+const TeamCard: React.FC<TeamCardProps> = ({ team, onRemove }) => {
+  return (
+    <View style={styles.card}>
+      <View style={styles.infoContainer}>
+        <Text style={styles.name}>{team.name}</Text>
+        {team.city ? <Text style={styles.detail}>City: {team.city}</Text> : null}
+        {team.coach ? <Text style={styles.detail}>Coach: {team.coach}</Text> : null}
+        {Array.isArray(team.players) && team.players.length > 0 ? (
+          <Text style={styles.detail}>Players: {team.players.length}</Text>
+        ) : null}
+      </View>
+      <TouchableOpacity onPress={onRemove} style={styles.removeButton}>
+        <Text style={styles.removeButtonText}>Remove</Text>
+      </TouchableOpacity>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  card: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    padding: 16,
+    marginVertical: 8,
+    borderRadius: 8,
+    backgroundColor: '#ffffff',
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.1,
+    shadowRadius: 4,
+    elevation: 2,
+  },
+  infoContainer: {
+    flex: 1,
+    marginRight: 16,
+  },
+  name: {
+    fontSize: 18,
+    fontWeight: 'bold',
+    marginBottom: 4,
+  },
+  detail: {
+    fontSize: 14,
+    color: '#555',
+  },
+  removeButton: {
+    paddingVertical: 8,
+    paddingHorizontal: 12,
+    borderRadius: 4,
+    backgroundColor: '#ff4d4f',
+  },
+  removeButtonText: {
+    color: '#fff',
+    fontWeight: '600',
+  },
+});
+
+export default TeamCard;

--- a/football-app/src/screens/TeamScreen.tsx
+++ b/football-app/src/screens/TeamScreen.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { View, Text, Button, FlatList } from 'react-native';
 import { useSelector, useDispatch } from 'react-redux';
-import { RootState } from '../store';
+import { RootState, AppDispatch } from '../store';
 import { removeTeam } from '../store/slices/teamsSlice';
 import TeamCard from '../components/TeamCard';
 
 const TeamScreen = () => {
-    const dispatch = useDispatch();
+    const dispatch = useDispatch<AppDispatch>();
     const teams = useSelector((state: RootState) => state.teams.teams);
 
     const handleRemoveTeam = (teamId: string) => {

--- a/football-app/src/store/index.ts
+++ b/football-app/src/store/index.ts
@@ -1,0 +1,13 @@
+import { configureStore } from '@reduxjs/toolkit';
+import teamsReducer from './slices/teamsSlice';
+
+export const store = configureStore({
+  reducer: {
+    teams: teamsReducer,
+  },
+});
+
+export type RootState = ReturnType<typeof store.getState>;
+export type AppDispatch = typeof store.dispatch;
+
+export default store;

--- a/football-app/src/store/slices/teamsSlice.ts
+++ b/football-app/src/store/slices/teamsSlice.ts
@@ -1,0 +1,32 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+export interface Team {
+  id: string;
+  name: string;
+  coach?: string;
+  city?: string;
+  founded?: number;
+  players?: string[];
+}
+
+export interface TeamsState {
+  teams: Team[];
+}
+
+const initialState: TeamsState = {
+  teams: [],
+};
+
+const teamsSlice = createSlice({
+  name: 'teams',
+  initialState,
+  reducers: {
+    removeTeam: (state, action: PayloadAction<string>) => {
+      state.teams = state.teams.filter((team) => team.id !== action.payload);
+    },
+  },
+});
+
+export const { removeTeam } = teamsSlice.actions;
+
+export default teamsSlice.reducer;


### PR DESCRIPTION
## Summary
- configure a Redux Toolkit store and teams slice for managing team state
- add a reusable TeamCard component to display team info with a remove action
- wrap the navigation container with the Redux provider so screens can access the store

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e188463048832eadc628e635abb754