### PR TITLE
Make npm install work offline

### DIFF
--- a/football-app/README.md
+++ b/football-app/README.md
@@ -24,15 +24,15 @@ To get started with the Football App, follow these steps:
    ```bash
    npm install
    ```
-   This project reuses the Expo workspace that lives in `football-app-expo/`. During installation a postinstall script links the
-   pre-populated `football-app-expo/node_modules` directory so the React Native bundle can resolve packages without reaching the
-   public npm registry. If access to the public registry is blocked (for example, in a restricted CI environment), you can still
-   prepare the dependencies without a network connection by running:
+   This project reuses the Expo workspace that lives in `football-app-expo/`. The tooling now ensures the symbolic link to the
+   vendored `football-app-expo/node_modules` directory is recreated automatically before installs, tests, builds, or Metro
+   sessions run, so you can run the usual npm scripts without worrying about registry access. If you want to refresh the link
+   manually—for example after cleaning the workspace—use the helper script:
    ```bash
-   npm run prepare:deps
+   npm run link:modules
    ```
-   When you need to refresh the dependencies, run `npm install` inside `football-app-expo/` (which already vendors the required
-   packages in this repository).
+   When you need to refresh the dependencies themselves, run `npm install` inside `football-app-expo/` (which already vendors the
+   required packages in this repository).
 
 3. **Run the Application**:
    ```bash

--- a/football-app/package.json
+++ b/football-app/package.json
@@ -12,7 +12,9 @@
     "prepare:deps": "node scripts/link-node-modules.js",
     "postinstall": "node scripts/link-node-modules.js"
   },
-  "dependencies": {
+  "dependencies": {},
+  "devDependencies": {},
+  "vendoredDependencies": {
     "@react-native-async-storage/async-storage": "^1.23.1",
     "@react-navigation/native": "^7.1.17",
     "@react-navigation/native-stack": "^7.3.25",
@@ -29,7 +31,7 @@
     "react-redux": "^9.2.0",
     "redux": "^4.1.0"
   },
-  "devDependencies": {
+  "vendoredDevDependencies": {
     "@types/node": "^24.3.0",
     "@types/react": "^19.1.11",
     "@types/react-native": "^0.73.0",

--- a/football-app/package.json
+++ b/football-app/package.json
@@ -5,12 +5,16 @@
   "main": "src/App.tsx",
   "private": true,
   "scripts": {
+    "link:modules": "node scripts/link-node-modules.js",
+    "prestart": "npm run link:modules",
     "start": "react-native start",
+    "prebuild": "npm run link:modules",
     "build": "react-native build",
+    "pretest": "npm run link:modules",
     "test": "node scripts/run-tests.js",
     "eject": "react-native eject",
-    "prepare:deps": "node scripts/link-node-modules.js",
-    "postinstall": "node scripts/link-node-modules.js"
+    "prepare:deps": "npm run link:modules",
+    "postinstall": "npm run link:modules"
   },
   "dependencies": {},
   "devDependencies": {},


### PR DESCRIPTION
## Summary
- move the Expo vendored packages out of the live dependency lists
- record the vendored runtime and dev dependencies for documentation only
- rely on the postinstall linker so `npm install` succeeds without registry access

## Testing
- npm install
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e1b0cdd758832ea9e2a504d9c7621a