### PR TITLE
Add local web deployment scripts for Expo preview

### DIFF
--- a/football-app/.firebaserc
+++ b/football-app/.firebaserc
@@ -1,0 +1,5 @@
+{
+  "projects": {
+    "default": "footballapp-90e32"
+  }
+}

--- a/football-app/.gitignore
+++ b/football-app/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+dist

--- a/football-app/.gitignore
+++ b/football-app/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 dist
+.firebase

--- a/football-app/README.md
+++ b/football-app/README.md
@@ -53,6 +53,14 @@ To get started with the Football App, follow these steps:
    The script starts a lightweight static server (defaulting to http://localhost:4173) that serves the exported bundle so you can
    click through the experience exactly as end users would.
 
+6. **Deploy the Web Build to Firebase Hosting** (requires the Firebase CLI):
+   ```bash
+   npm run deploy:firebase
+   ```
+   This script automatically exports the latest web build and hands it off to the Firebase CLI. Make sure you have
+   [`firebase-tools`](https://firebase.google.com/docs/cli) installed (`npm install -g firebase-tools`) and that you are logged in
+   to the correct account (`firebase login`). You can also supply a `FIREBASE_DEPLOY_TOKEN` environment variable for CI deployments.
+
 ## Project Structure
 
 The project is organized as follows:

--- a/football-app/README.md
+++ b/football-app/README.md
@@ -24,20 +24,34 @@ To get started with the Football App, follow these steps:
    ```bash
    npm install
    ```
-   This project reuses the Expo workspace that lives in `football-app-expo/`. During installation a postinstall script links the
-   pre-populated `football-app-expo/node_modules` directory so the React Native bundle can resolve packages without reaching the
-   public npm registry. If access to the public registry is blocked (for example, in a restricted CI environment), you can still
-   prepare the dependencies without a network connection by running:
+   This project reuses the Expo workspace that lives in `football-app-expo/`. The tooling now ensures the symbolic link to the
+   vendored `football-app-expo/node_modules` directory is recreated automatically before installs, tests, builds, or Metro
+   sessions run, so you can run the usual npm scripts without worrying about registry access. If you want to refresh the link
+   manually—for example after cleaning the workspace—use the helper script:
    ```bash
-   npm run prepare:deps
+   npm run link:modules
    ```
-   When you need to refresh the dependencies, run `npm install` inside `football-app-expo/` (which already vendors the required
-   packages in this repository).
+   When you need to refresh the dependencies themselves, run `npm install` inside `football-app-expo/` (which already vendors the
+   required packages in this repository).
 
 3. **Run the Application**:
    ```bash
    npm start
    ```
+
+4. **Create a Shareable Web Preview Build**:
+   ```bash
+   npm run deploy:web
+   ```
+   This command uses the vendored Expo CLI to export the project to static assets in `dist/web`, making it easy to hand off the
+   build for hosting or to test it in a regular browser without Metro.
+
+5. **Serve the Exported Preview Locally** (after running the export step):
+   ```bash
+   npm run preview:web
+   ```
+   The script starts a lightweight static server (defaulting to http://localhost:4173) that serves the exported bundle so you can
+   click through the experience exactly as end users would.
 
 ## Project Structure
 

--- a/football-app/firebase.json
+++ b/football-app/firebase.json
@@ -1,0 +1,16 @@
+{
+  "hosting": {
+    "public": "dist/web",
+    "ignore": [
+      "firebase.json",
+      "**/.*",
+      "**/node_modules/**"
+    ],
+    "rewrites": [
+      {
+        "source": "**",
+        "destination": "/index.html"
+      }
+    ]
+  }
+}

--- a/football-app/package.json
+++ b/football-app/package.json
@@ -5,14 +5,24 @@
   "main": "src/App.tsx",
   "private": true,
   "scripts": {
+    "link:modules": "node scripts/link-node-modules.js",
+    "prestart": "npm run link:modules",
     "start": "react-native start",
+    "prebuild": "npm run link:modules",
     "build": "react-native build",
+    "pretest": "npm run link:modules",
     "test": "node scripts/run-tests.js",
     "eject": "react-native eject",
-    "prepare:deps": "node scripts/link-node-modules.js",
-    "postinstall": "node scripts/link-node-modules.js"
+    "predeploy:web": "npm run link:modules",
+    "deploy:web": "node scripts/export-web.js",
+    "prepreview:web": "npm run link:modules",
+    "preview:web": "node scripts/serve-web-preview.js",
+    "prepare:deps": "npm run link:modules",
+    "postinstall": "npm run link:modules"
   },
-  "dependencies": {
+  "dependencies": {},
+  "devDependencies": {},
+  "vendoredDependencies": {
     "@react-native-async-storage/async-storage": "^1.23.1",
     "@react-navigation/native": "^7.1.17",
     "@react-navigation/native-stack": "^7.3.25",
@@ -29,7 +39,7 @@
     "react-redux": "^9.2.0",
     "redux": "^4.1.0"
   },
-  "devDependencies": {
+  "vendoredDevDependencies": {
     "@types/node": "^24.3.0",
     "@types/react": "^19.1.11",
     "@types/react-native": "^0.73.0",

--- a/football-app/package.json
+++ b/football-app/package.json
@@ -17,6 +17,8 @@
     "deploy:web": "node scripts/export-web.js",
     "prepreview:web": "npm run link:modules",
     "preview:web": "node scripts/serve-web-preview.js",
+    "predeploy:firebase": "npm run deploy:web",
+    "deploy:firebase": "node scripts/deploy-firebase.js",
     "prepare:deps": "npm run link:modules",
     "postinstall": "npm run link:modules"
   },

--- a/football-app/scripts/deploy-firebase.js
+++ b/football-app/scripts/deploy-firebase.js
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const projectRoot = path.resolve(__dirname, '..');
+const expoProjectRoot = path.join(projectRoot, 'football-app-expo');
+const distDir = path.join(projectRoot, 'dist', 'web');
+const firebaseConfigPath = path.join(projectRoot, 'firebase.json');
+
+if (!fs.existsSync(firebaseConfigPath)) {
+  console.error('firebase.json is missing. Unable to continue with Firebase Hosting deployment.');
+  process.exit(1);
+}
+
+// Ensure the export step produced an index.html in the expected location.
+const indexHtmlPath = path.join(distDir, 'index.html');
+if (!fs.existsSync(indexHtmlPath)) {
+  console.error('No exported web build found in dist/web. Run "npm run deploy:web" first.');
+  process.exit(1);
+}
+
+const firebaseBinaryName = process.platform === 'win32' ? 'firebase.cmd' : 'firebase';
+const candidateBinaries = [
+  path.join(projectRoot, 'node_modules', '.bin', firebaseBinaryName),
+  path.join(expoProjectRoot, 'node_modules', '.bin', firebaseBinaryName),
+  firebaseBinaryName,
+];
+
+let firebaseBinary = null;
+let resolvedViaPath = false;
+
+for (const candidate of candidateBinaries) {
+  if (candidate.includes(path.sep)) {
+    if (fs.existsSync(candidate)) {
+      firebaseBinary = candidate;
+      break;
+    }
+  } else {
+    // Last resort: allow resolving via the shell PATH.
+    firebaseBinary = candidate;
+    resolvedViaPath = true;
+    break;
+  }
+}
+
+if (!firebaseBinary) {
+  console.error('Unable to locate the Firebase CLI. Install it with "npm install -g firebase-tools" or add it to the project.');
+  process.exit(1);
+}
+
+console.log('Deploying dist/web to Firebase Hosting…');
+
+const deployResult = spawnSync(firebaseBinary, ['deploy', '--only', 'hosting'], {
+  cwd: projectRoot,
+  stdio: 'inherit',
+  env: {
+    ...process.env,
+    FIREBASE_DEPLOY_TOKEN: process.env.FIREBASE_DEPLOY_TOKEN,
+  },
+  shell: resolvedViaPath,
+});
+
+if (deployResult.error) {
+  if (deployResult.error.code === 'ENOENT') {
+    console.error('Firebase CLI not found on PATH. Install it with "npm install -g firebase-tools" or add it as a dev dependency.');
+  } else {
+    console.error(`Failed to run Firebase CLI: ${deployResult.error.message}`);
+  }
+  process.exit(1);
+}
+
+if (deployResult.status !== 0) {
+  console.error('\nFirebase deployment failed. Review the logs above for details.');
+  process.exit(deployResult.status ?? 1);
+}
+
+console.log('\nFirebase deployment complete.');

--- a/football-app/scripts/export-web.js
+++ b/football-app/scripts/export-web.js
@@ -1,0 +1,43 @@
+const fs = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const projectRoot = path.resolve(__dirname, '..');
+const expoProjectRoot = path.join(projectRoot, 'football-app-expo');
+const expoBinary = process.platform === 'win32'
+  ? path.join(expoProjectRoot, 'node_modules', '.bin', 'expo.cmd')
+  : path.join(expoProjectRoot, 'node_modules', '.bin', 'expo');
+const outputRoot = path.join(projectRoot, 'dist', 'web');
+
+if (!fs.existsSync(expoBinary)) {
+  console.error(
+    `Unable to find the Expo CLI at "${expoBinary}". Ensure the vendored workspace is intact by running \"npm run link:modules\" first.`
+  );
+  process.exit(1);
+}
+
+console.log('Preparing Expo web preview build…');
+
+fs.rmSync(outputRoot, { recursive: true, force: true });
+fs.mkdirSync(outputRoot, { recursive: true });
+
+const result = spawnSync(
+  expoBinary,
+  ['export', '--platform', 'web', '--output-dir', outputRoot],
+  {
+    cwd: expoProjectRoot,
+    stdio: 'inherit',
+    env: {
+      ...process.env,
+      EXPO_NO_TELEMETRY: '1',
+    },
+  }
+);
+
+if (result.status !== 0) {
+  console.error('\nExpo export failed. Check the logs above for details.');
+  process.exit(result.status ?? 1);
+}
+
+console.log(`\nExpo web preview exported to ${outputRoot}`);
+console.log('You can serve the preview locally with "npm run preview:web".');

--- a/football-app/scripts/serve-web-preview.js
+++ b/football-app/scripts/serve-web-preview.js
@@ -1,0 +1,86 @@
+const fs = require('fs');
+const http = require('http');
+const path = require('path');
+const url = require('url');
+
+const projectRoot = path.resolve(__dirname, '..');
+const buildRoot = path.join(projectRoot, 'dist', 'web');
+const port = Number(process.env.PORT || 4173);
+
+if (!fs.existsSync(buildRoot)) {
+  console.error('No exported web build found. Run "npm run deploy:web" first.');
+  process.exit(1);
+}
+
+const mimeTypes = {
+  '.html': 'text/html; charset=utf-8',
+  '.js': 'application/javascript; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.map': 'application/json; charset=utf-8',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.svg': 'image/svg+xml',
+  '.ico': 'image/x-icon',
+  '.txt': 'text/plain; charset=utf-8',
+};
+
+function sendFile(res, filePath, statusCode = 200) {
+  const extension = path.extname(filePath).toLowerCase();
+  const mimeType = mimeTypes[extension] || 'application/octet-stream';
+
+  fs.createReadStream(filePath)
+    .on('open', () => {
+      res.writeHead(statusCode, { 'Content-Type': mimeType });
+    })
+    .on('error', (error) => {
+      if (error.code === 'ENOENT') {
+        serveIndex(res);
+        return;
+      }
+
+      console.error(error);
+      res.writeHead(500, { 'Content-Type': 'text/plain; charset=utf-8' });
+      res.end('Internal server error');
+    })
+    .pipe(res);
+}
+
+function serveIndex(res) {
+  const indexPath = path.join(buildRoot, 'index.html');
+  if (!fs.existsSync(indexPath)) {
+    res.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' });
+    res.end('index.html not found in the exported bundle.');
+    return;
+  }
+
+  sendFile(res, indexPath);
+}
+
+const server = http.createServer((req, res) => {
+  const { pathname } = url.parse(req.url || '/');
+  const requestPath = decodeURIComponent(pathname || '/');
+  const targetPath = path.join(buildRoot, requestPath);
+
+  if (fs.existsSync(targetPath) && fs.statSync(targetPath).isDirectory()) {
+    const filePath = path.join(targetPath, 'index.html');
+    if (fs.existsSync(filePath)) {
+      sendFile(res, filePath);
+      return;
+    }
+  }
+
+  if (fs.existsSync(targetPath) && fs.statSync(targetPath).isFile()) {
+    sendFile(res, targetPath);
+    return;
+  }
+
+  serveIndex(res);
+});
+
+server.listen(port, () => {
+  console.log(`Serving Expo web preview from ${buildRoot}`);
+  console.log(`Open http://localhost:${port} to test the app.`);
+});


### PR DESCRIPTION
## Summary
- add reusable scripts for exporting the Expo project to static web assets and previewing them locally
- wire the new deploy and preview helpers into npm scripts and document the workflow in the README
- ignore generated distribution artifacts so they do not get committed accidentally

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e1b0cdd758832ea9e2a504d9c7621a