### PR TITLE
Verify Firebase CLI availability before deploy

### DIFF
--- a/football-app/.github/workflows/deploy-firebase.yml
+++ b/football-app/.github/workflows/deploy-firebase.yml
@@ -24,6 +24,10 @@ jobs:
           cache: npm
           cache-dependency-path: football-app/package-lock.json
 
+      - name: Install Expo workspace dependencies
+        working-directory: football-app/football-app-expo
+        run: npm install
+
       - name: Install dependencies
         working-directory: football-app
         run: npm install
@@ -32,8 +36,13 @@ jobs:
         working-directory: football-app
         run: npm test
 
-      - name: Install Firebase CLI
-        run: npm install --global firebase-tools
+      - name: Install Firebase CLI locally
+        working-directory: football-app
+        run: npm install --no-save firebase-tools
+
+      - name: Verify Firebase CLI availability
+        working-directory: football-app
+        run: npx firebase --version
 
       - name: Deploy to Firebase Hosting
         working-directory: football-app


### PR DESCRIPTION
## Summary
- add an explicit verification step to ensure firebase-tools is available after the local installation during CI

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e1e1dbde44832eace16195c1117ed6