### PR TITLE
Ensure Firebase deploy script passes CI token

### DIFF
--- a/football-app/.github/workflows/deploy-firebase.yml
+++ b/football-app/.github/workflows/deploy-firebase.yml
@@ -24,6 +24,10 @@ jobs:
           cache: npm
           cache-dependency-path: football-app/package-lock.json
 
+      - name: Install Expo workspace dependencies
+        working-directory: football-app/football-app-expo
+        run: npm install
+
       - name: Install dependencies
         working-directory: football-app
         run: npm install
@@ -32,8 +36,13 @@ jobs:
         working-directory: football-app
         run: npm test
 
-      - name: Install Firebase CLI
-        run: npm install --global firebase-tools
+      - name: Install Firebase CLI locally
+        working-directory: football-app
+        run: npm install --no-save firebase-tools
+
+      - name: Verify Firebase CLI availability
+        working-directory: football-app
+        run: npx firebase --version
 
       - name: Deploy to Firebase Hosting
         working-directory: football-app

--- a/football-app/README.md
+++ b/football-app/README.md
@@ -76,6 +76,7 @@ To get started with the Football App, follow these steps:
   - `FIREBASE_APP_ID`
   - `FIREBASE_MEASUREMENT_ID` (optional, required only if Analytics is enabled)
 - The workflow installs dependencies, runs the existing tests, exports the Expo web build, and deploys it to Firebase Hosting using the same helper scripts that are available locally.
+- If the deploy step fails with `Failed to authenticate, have you run firebase login?`, regenerate the CI token locally with `firebase login:ci` (or `firebase login:token`), update the `FIREBASE_DEPLOY_TOKEN` secret under **Settings → Secrets and variables → Actions**, and re-run the workflow. This ensures GitHub Actions can authenticate against your Firebase project.
 
 ## Project Structure
 

--- a/football-app/scripts/deploy-firebase.js
+++ b/football-app/scripts/deploy-firebase.js
@@ -88,7 +88,19 @@ if (process.env.FIREBASE_DEPLOY_TOKEN) {
   deployEnv.FIREBASE_DEPLOY_TOKEN = process.env.FIREBASE_DEPLOY_TOKEN;
 }
 
-const deployResult = spawnSync(firebaseBinary, ['deploy', '--only', 'hosting'], {
+const deployArgs = ['deploy', '--only', 'hosting'];
+const firebaseDeployToken =
+  process.env.FIREBASE_DEPLOY_TOKEN || process.env.FIREBASE_TOKEN || '';
+
+if (firebaseDeployToken) {
+  // Pass the token explicitly so the CLI never prompts for interactive auth.
+  deployArgs.push('--token', firebaseDeployToken);
+  // Normalise the environment variable name for firebase-tools (which still
+  // reads FIREBASE_TOKEN in some code paths) to avoid future regressions.
+  deployEnv.FIREBASE_TOKEN = firebaseDeployToken;
+}
+
+const deployResult = spawnSync(firebaseBinary, deployArgs, {
   cwd: projectRoot,
   stdio: 'inherit',
   env: deployEnv,


### PR DESCRIPTION
## Summary
- ensure the Firebase deploy helper always forwards the FIREBASE_DEPLOY_TOKEN to the CLI
- normalise the token to FIREBASE_TOKEN for compatibility with older firebase-tools behaviour

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e1e1dbde44832eace16195c1117ed6