### PR TITLE
Configure Firebase deploy workflow to use token

### DIFF
--- a/football-app/.github/workflows/deploy-firebase.yml
+++ b/football-app/.github/workflows/deploy-firebase.yml
@@ -51,6 +51,7 @@ jobs:
         working-directory: football-app
         env:
           GOOGLE_APPLICATION_CREDENTIALS: ${{ env.GOOGLE_APPLICATION_CREDENTIALS }}
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
         run: |
           npm install --global firebase-tools
-          firebase deploy --only hosting
+          firebase deploy --only hosting --token "$FIREBASE_TOKEN"


### PR DESCRIPTION
## Summary
- export the FIREBASE_TOKEN secret when deploying to Firebase Hosting
- pass the token to the firebase deploy command so it can authenticate non-interactively

## Testing
- not run (CI workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68e439e2bf1c832e9873bdfc57234b43