### PR TITLE
Fail fast when Firebase token secret is missing

### DIFF
--- a/football-app/.github/workflows/deploy-firebase.yml
+++ b/football-app/.github/workflows/deploy-firebase.yml
@@ -51,6 +51,11 @@ jobs:
         working-directory: football-app
         env:
           GOOGLE_APPLICATION_CREDENTIALS: ${{ env.GOOGLE_APPLICATION_CREDENTIALS }}
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
         run: |
+          if [ -z "$FIREBASE_TOKEN" ]; then
+            echo "\"FIREBASE_TOKEN\" secret is missing. Add it in the repository settings to enable non-interactive Firebase authentication." >&2
+            exit 1
+          fi
           npm install --global firebase-tools
-          firebase deploy --only hosting
+          firebase deploy --only hosting --token "$FIREBASE_TOKEN"


### PR DESCRIPTION
## Summary
- add an explicit guard in the deploy step to detect when FIREBASE_TOKEN is absent
- emit a clear error message instructing maintainers to add the secret before attempting a deploy

## Testing
- not run (CI workflow change)

------
https://chatgpt.com/codex/tasks/task_e_68e439e2bf1c832e9873bdfc57234b43