### PR TITLE
Ensure Firebase token is validated before deploy

### DIFF
--- a/football-app/.github/workflows/deploy-firebase.yml
+++ b/football-app/.github/workflows/deploy-firebase.yml
@@ -12,6 +12,8 @@ permissions:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    env:
+      FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
 
     steps:
       - name: Check out repository
@@ -47,10 +49,16 @@ jobs:
           EOF
           echo "GOOGLE_APPLICATION_CREDENTIALS=${RUNNER_TEMP}/firebase-service-account.json" >> "$GITHUB_ENV"
 
+      - name: Verify Firebase token is configured
+        if: ${{ env.FIREBASE_TOKEN == '' }}
+        run: |
+          echo '"FIREBASE_TOKEN" secret is missing. Add it in the repository settings to enable non-interactive Firebase authentication.' >&2
+          exit 1
+
       - name: Deploy to Firebase Hosting
         working-directory: football-app
         env:
           GOOGLE_APPLICATION_CREDENTIALS: ${{ env.GOOGLE_APPLICATION_CREDENTIALS }}
         run: |
           npm install --global firebase-tools
-          firebase deploy --only hosting
+          firebase deploy --only hosting --token "$FIREBASE_TOKEN"


### PR DESCRIPTION
## Summary
- export the FIREBASE_TOKEN secret at the job level for reuse across steps
- add a dedicated guard step that aborts with a clear message when the token is missing
- simplify the deploy step to rely on the shared token and still pass it to firebase deploy

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e439e2bf1c832e9873bdfc57234b43