### PR TITLE
Document deploy fixes and use Node 20

### DIFF
--- a/.github/workflows/deploy-firebase.yml
+++ b/.github/workflows/deploy-firebase.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
           cache: npm
           cache-dependency-path: football-app/package-lock.json
 

--- a/TASKS.md
+++ b/TASKS.md
@@ -1,0 +1,17 @@
+# Deployment Fix Tasks
+
+## 1. Provide Firebase service account credentials
+- [ ] Open the Firebase project in the Google Cloud console.
+- [ ] Create or locate a service account with **Firebase Hosting Admin** and **Service Account Token Creator** roles.
+- [ ] Generate a JSON key for the account and copy the entire file content.
+- [ ] In GitHub → **Settings** → **Secrets and variables** → **Actions**, create a secret named `FIREBASE_SERVICE_ACCOUNT_KEY` that contains the JSON.
+- [ ] Re-run the "Deploy to Firebase Hosting" workflow and confirm the `Configure Firebase credentials` step succeeds.
+
+## 2. Verify Node.js 20 compatibility
+- [ ] Re-run the deploy workflow after updating the secret.
+- [ ] Confirm the `Set up Node.js` step now installs Node 20 without `EBADENGINE` warnings from Firebase packages.
+- [ ] Validate the Expo build, tests, and Firebase deploy steps still complete successfully.
+
+## 3. Monitor follow-up maintenance
+- [ ] Run `npm audit` locally and address high-severity vulnerabilities as needed.
+- [ ] Consider pruning deprecated dependencies (e.g., `glob@7`, `uuid@3`, `rimraf@3`) during a scheduled dependency update.


### PR DESCRIPTION
## Summary
- update the deploy workflow to install Node.js 20 so Firebase packages stop emitting engine warnings
- add TASKS.md with a checklist covering the Firebase secret setup and follow-up maintenance steps

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4411090f0832ea33ae90efb9fab2c