### PR TITLE
Use Node to validate Firebase credentials in deploy workflow

### DIFF
--- a/.github/workflows/deploy-firebase.yml
+++ b/.github/workflows/deploy-firebase.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
           cache: npm
           cache-dependency-path: football-app/package-lock.json
 
@@ -41,16 +41,107 @@ jobs:
         run: npm run deploy:web
 
       - name: Configure Firebase credentials
+        id: firebase-credentials
         run: |
-          cat <<EOF > "${RUNNER_TEMP}/firebase-service-account.json"
-          ${{ secrets.FIREBASE_SERVICE_ACCOUNT_KEY }}
-          EOF
-          echo "GOOGLE_APPLICATION_CREDENTIALS=${RUNNER_TEMP}/firebase-service-account.json" >> "$GITHUB_ENV"
+          set -euo pipefail
+
+          credentials_path="${RUNNER_TEMP}/firebase-service-account.json"
+          service_account_raw='${{ secrets.FIREBASE_SERVICE_ACCOUNT_KEY }}'
+          service_account_b64='${{ secrets.FIREBASE_SERVICE_ACCOUNT_KEY_BASE64 }}'
+          deploy_token='${{ secrets.FIREBASE_DEPLOY_TOKEN }}'
+
+          if [ -n "${service_account_raw}" ] || [ -n "${service_account_b64}" ]; then
+            export CREDENTIALS_PATH="${credentials_path}"
+            export FIREBASE_SERVICE_ACCOUNT_KEY_RAW="${service_account_raw}"
+            export FIREBASE_SERVICE_ACCOUNT_KEY_BASE64="${service_account_b64}"
+
+            if ! node - <<'NODE'; then
+              exit 1
+            fi
+
+const fs = require('fs');
+
+const path = process.env.CREDENTIALS_PATH;
+const raw = process.env.FIREBASE_SERVICE_ACCOUNT_KEY_RAW || '';
+const b64 = process.env.FIREBASE_SERVICE_ACCOUNT_KEY_BASE64 || '';
+
+let content = raw.trim();
+
+if (!content) {
+  const normalised = b64.replace(/\s+/g, '');
+
+  if (!normalised) {
+    console.log('::error::Firebase service account secret is empty. Provide FIREBASE_SERVICE_ACCOUNT_KEY or FIREBASE_SERVICE_ACCOUNT_KEY_BASE64.');
+    process.exit(1);
+  }
+
+  if (!/^[A-Za-z0-9+/=_-]+$/.test(normalised)) {
+    console.log('::error::FIREBASE_SERVICE_ACCOUNT_KEY_BASE64 is not valid base64 data.');
+    process.exit(1);
+  }
+
+  try {
+    let decodeSource = normalised.replace(/-/g, '+').replace(/_/g, '/');
+    if (decodeSource.length % 4 !== 0) {
+      decodeSource = decodeSource.padEnd(decodeSource.length + (4 - (decodeSource.length % 4)), '=');
+    }
+
+    const decoded = Buffer.from(decodeSource, 'base64');
+    const reencoded = decoded.toString('base64').replace(/=+$/, '');
+    const expected = decodeSource.replace(/=+$/, '');
+
+    if (!decoded.length || reencoded !== expected) {
+      throw new Error('Decoded content is empty or corrupted.');
+    }
+
+    content = decoded.toString('utf8');
+  } catch (error) {
+    console.log(`::error::Failed to decode FIREBASE_SERVICE_ACCOUNT_KEY_BASE64: ${error.message}`);
+    process.exit(1);
+  }
+}
+
+const trimmed = content.trim();
+
+if (!trimmed) {
+  console.log('::error::Firebase service account key is empty after decoding.');
+  process.exit(1);
+}
+
+try {
+  JSON.parse(trimmed);
+} catch (error) {
+  console.log(`::error::Firebase service account key is not valid JSON: ${error.message}`);
+  process.exit(1);
+}
+
+fs.writeFileSync(path, trimmed, { encoding: 'utf8', mode: 0o600 });
+NODE
+
+            echo "GOOGLE_APPLICATION_CREDENTIALS=${credentials_path}" >> "$GITHUB_ENV"
+            echo "credentials_path=${credentials_path}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ -n "${deploy_token}" ]; then
+            echo "deploy_token=${deploy_token}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo '::error::Configure FIREBASE_SERVICE_ACCOUNT_KEY (preferred), FIREBASE_SERVICE_ACCOUNT_KEY_BASE64, or FIREBASE_DEPLOY_TOKEN so the deploy step can authenticate.'
+          exit 1
 
       - name: Deploy to Firebase Hosting
         working-directory: football-app
         env:
-          GOOGLE_APPLICATION_CREDENTIALS: ${{ env.GOOGLE_APPLICATION_CREDENTIALS }}
+          GOOGLE_APPLICATION_CREDENTIALS: ${{ steps.firebase-credentials.outputs.credentials_path }}
+          FIREBASE_DEPLOY_TOKEN: ${{ steps.firebase-credentials.outputs.deploy_token }}
         run: |
+          set -euo pipefail
           npm install --global firebase-tools
-          firebase deploy --only hosting
+
+          if [ -n "${FIREBASE_DEPLOY_TOKEN:-}" ]; then
+            firebase deploy --only hosting --token "${FIREBASE_DEPLOY_TOKEN}"
+          else
+            firebase deploy --only hosting
+          fi

--- a/TASKS.md
+++ b/TASKS.md
@@ -1,0 +1,15 @@
+# Deployment Fix Tasks
+
+## 1. Provide Firebase credentials
+- [ ] Preferred: Open the Firebase project in the Google Cloud console, locate (or create) a service account with **Firebase Hosting Admin** and **Service Account Token Creator** roles, generate a JSON key, and store it verbatim in the `FIREBASE_SERVICE_ACCOUNT_KEY` repository secret (or upload a base64-encoded copy as `FIREBASE_SERVICE_ACCOUNT_KEY_BASE64` if your secret manager rejects multiline values).
+- [ ] Legacy fallback: If you cannot provision a service account yet, run `firebase login:ci` locally (or `npm run firebase:token`) and upload the generated token as `FIREBASE_DEPLOY_TOKEN`.
+- [ ] Re-run the "Deploy to Firebase Hosting" workflow and confirm the `Configure Firebase credentials` step detects either credential type and succeeds.
+
+## 2. Verify Node.js 20 compatibility
+- [ ] Re-run the deploy workflow after updating the secret.
+- [ ] Confirm the `Set up Node.js` step now installs Node 20 without `EBADENGINE` warnings from Firebase packages.
+- [ ] Validate the Expo build, tests, and Firebase deploy steps still complete successfully.
+
+## 3. Monitor follow-up maintenance
+- [ ] Run `npm audit` locally and address high-severity vulnerabilities as needed.
+- [ ] Consider pruning deprecated dependencies (e.g., `glob@7`, `uuid@3`, `rimraf@3`) during a scheduled dependency update.

--- a/football-app/README.md
+++ b/football-app/README.md
@@ -130,9 +130,9 @@ secret (for example, `FIREBASE_DEPLOY_TOKEN`):
 
 - A `Deploy to Firebase Hosting` workflow lives at `.github/workflows/deploy-firebase.yml`.
 - It runs on pushes to `main` and can also be invoked manually through the **Run workflow** button.
-- Populate the `FIREBASE_SERVICE_ACCOUNT_KEY` repository secret with a Firebase service account JSON key that has Hosting permissions. The workflow materialises this secret to a temporary file and exports it via `GOOGLE_APPLICATION_CREDENTIALS` so the Firebase CLI can authenticate non-interactively.
+- Populate the `FIREBASE_SERVICE_ACCOUNT_KEY` repository secret with a Firebase service account JSON key that has Hosting permissions. If your secret manager struggles with multiline values, store a base64-encoded version of the JSON in `FIREBASE_SERVICE_ACCOUNT_KEY_BASE64` instead. The workflow materialises whichever secret is present to a temporary file and exports it via `GOOGLE_APPLICATION_CREDENTIALS` so the Firebase CLI can authenticate non-interactively. If you are still relying on legacy CI tokens, you can instead provide a `FIREBASE_DEPLOY_TOKEN` secret—the workflow falls back to `firebase deploy --token <value>` only when no service account key is available.
 - The workflow installs dependencies, runs the existing tests, exports the Expo web build, and deploys it to Firebase Hosting using the same helper scripts that are available locally.
-- If the deploy step fails with authentication errors, re-generate the service account key from **Project Settings → Service Accounts → Generate new private key**, update the `FIREBASE_SERVICE_ACCOUNT_KEY` secret, and re-run the workflow.
+- If the deploy step fails with authentication errors, re-generate the service account key from **Project Settings → Service Accounts → Generate new private key**, update the `FIREBASE_SERVICE_ACCOUNT_KEY` secret (or refresh the `FIREBASE_DEPLOY_TOKEN`), and re-run the workflow.
 
 ## Project Structure
 


### PR DESCRIPTION
## Summary
- replace the Python helper with a Node.js validator so the workflow only depends on the runtime installed by actions/setup-node
- normalise and verify base64 secrets, accepting URL-safe encodings and guarding against malformed data before writing the credentials file
- keep the workflow outputs unchanged so the deploy step still supports either service-account keys or legacy deploy tokens

## Testing
- not run (workflow change only)

------
https://chatgpt.com/codex/tasks/task_e_68e4411090f0832ea33ae90efb9fab2c