### PR TITLE
Ensure Firebase deploy uses resolved project id

### DIFF
--- a/.github/scripts/validate-firebase-credentials.cjs
+++ b/.github/scripts/validate-firebase-credentials.cjs
@@ -1,0 +1,77 @@
+const fs = require('fs');
+
+function fail(message) {
+  console.log(`::error::${message}`);
+  process.exit(1);
+}
+
+const path = process.env.CREDENTIALS_PATH;
+const raw = process.env.FIREBASE_SERVICE_ACCOUNT_KEY_RAW || '';
+const b64 = process.env.FIREBASE_SERVICE_ACCOUNT_KEY_BASE64 || '';
+
+if (!path) {
+  fail('CREDENTIALS_PATH is not defined.');
+}
+
+let content = raw.trim();
+
+if (!content) {
+  const normalised = b64.replace(/\s+/g, '');
+
+  if (!normalised) {
+    fail('Firebase service account secret is empty. Provide FIREBASE_SERVICE_ACCOUNT_KEY or FIREBASE_SERVICE_ACCOUNT_KEY_BASE64.');
+  }
+
+  if (!/^[A-Za-z0-9+/=_-]+$/.test(normalised)) {
+    fail('FIREBASE_SERVICE_ACCOUNT_KEY_BASE64 is not valid base64 data.');
+  }
+
+  try {
+    let decodeSource = normalised.replace(/-/g, '+').replace(/_/g, '/');
+
+    if (decodeSource.length % 4 !== 0) {
+      decodeSource = decodeSource.padEnd(decodeSource.length + (4 - (decodeSource.length % 4)), '=');
+    }
+
+    const decoded = Buffer.from(decodeSource, 'base64');
+    const reencoded = decoded.toString('base64').replace(/=+$/, '');
+    const expected = decodeSource.replace(/=+$/, '');
+
+    if (!decoded.length || reencoded !== expected) {
+      throw new Error('Decoded content is empty or corrupted.');
+    }
+
+    content = decoded.toString('utf8');
+  } catch (error) {
+    fail(`Failed to decode FIREBASE_SERVICE_ACCOUNT_KEY_BASE64: ${error.message}`);
+  }
+}
+
+const trimmed = content.trim();
+
+if (!trimmed) {
+  fail('Firebase service account key is empty after decoding.');
+}
+
+let parsed;
+try {
+  parsed = JSON.parse(trimmed);
+} catch (error) {
+  fail(`Firebase service account key is not valid JSON: ${error.message}`);
+}
+
+if (!parsed || parsed.type !== 'service_account') {
+  fail('Firebase credential must be a service account JSON key (type "service_account").');
+}
+
+if (!parsed.project_id) {
+  fail('Firebase service account JSON is missing "project_id".');
+}
+
+try {
+  fs.writeFileSync(path, trimmed, { encoding: 'utf8', mode: 0o600 });
+} catch (error) {
+  fail(`Failed to write credentials file: ${error.message}`);
+}
+
+module.exports = parsed;

--- a/.github/workflows/deploy-firebase.yml
+++ b/.github/workflows/deploy-firebase.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
           cache: npm
           cache-dependency-path: football-app/package-lock.json
 
@@ -41,16 +41,77 @@ jobs:
         run: npm run deploy:web
 
       - name: Configure Firebase credentials
+        id: firebase-credentials
+        env:
+          FIREBASE_SERVICE_ACCOUNT_KEY: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_KEY }}
+          FIREBASE_SERVICE_ACCOUNT_KEY_BASE64: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_KEY_BASE64 }}
+          FIREBASE_DEPLOY_TOKEN: ${{ secrets.FIREBASE_DEPLOY_TOKEN }}
         run: |
-          cat <<EOF > "${RUNNER_TEMP}/firebase-service-account.json"
-          ${{ secrets.FIREBASE_SERVICE_ACCOUNT_KEY }}
-          EOF
-          echo "GOOGLE_APPLICATION_CREDENTIALS=${RUNNER_TEMP}/firebase-service-account.json" >> "$GITHUB_ENV"
+          set -euo pipefail
+
+          credentials_path="${RUNNER_TEMP}/firebase-service-account.json"
+          service_account_raw="${FIREBASE_SERVICE_ACCOUNT_KEY:-}"
+          service_account_b64="${FIREBASE_SERVICE_ACCOUNT_KEY_BASE64:-}"
+          deploy_token="${FIREBASE_DEPLOY_TOKEN:-}"
+
+          if [ -n "${service_account_raw}" ] || [ -n "${service_account_b64}" ]; then
+            export CREDENTIALS_PATH="${credentials_path}"
+            export FIREBASE_SERVICE_ACCOUNT_KEY_RAW="${service_account_raw}"
+            export FIREBASE_SERVICE_ACCOUNT_KEY_BASE64="${service_account_b64}"
+
+            node .github/scripts/validate-firebase-credentials.cjs
+
+            project_id=$(node -e "const fs=require('fs');const data=JSON.parse(fs.readFileSync(process.argv[1],'utf8'));process.stdout.write(data.project_id||'');" "${credentials_path}")
+
+            if [ -z "${project_id}" ]; then
+              echo '::error::Firebase service account JSON is missing project_id.'
+              exit 1
+            fi
+
+            {
+              echo "FIREBASE_SERVICE_ACCOUNT<<'EOF'"
+              cat "${credentials_path}"
+              echo 'EOF'
+            } >> "$GITHUB_ENV"
+
+            echo "FIREBASE_PROJECT=${project_id}" >> "$GITHUB_ENV"
+            echo "project_id=${project_id}" >> "$GITHUB_OUTPUT"
+
+            echo "::notice::Using Firebase service account credentials for deployment."
+            echo "GOOGLE_APPLICATION_CREDENTIALS=${credentials_path}" >> "$GITHUB_ENV"
+            echo "credentials_path=${credentials_path}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ -n "${deploy_token}" ]; then
+            echo "::notice::Using Firebase deploy token for deployment."
+            echo "deploy_token=${deploy_token}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo '::error::Configure FIREBASE_SERVICE_ACCOUNT_KEY (preferred), FIREBASE_SERVICE_ACCOUNT_KEY_BASE64, or FIREBASE_DEPLOY_TOKEN so the deploy step can authenticate.'
+          exit 1
 
       - name: Deploy to Firebase Hosting
         working-directory: football-app
         env:
-          GOOGLE_APPLICATION_CREDENTIALS: ${{ env.GOOGLE_APPLICATION_CREDENTIALS }}
+          GOOGLE_APPLICATION_CREDENTIALS: ${{ steps.firebase-credentials.outputs.credentials_path }}
+          FIREBASE_DEPLOY_TOKEN: ${{ steps.firebase-credentials.outputs.deploy_token }}
+          FIREBASE_PROJECT: ${{ steps.firebase-credentials.outputs.project_id }}
         run: |
+          set -euo pipefail
           npm install --global firebase-tools
-          firebase deploy --only hosting
+
+          if [ -n "${FIREBASE_DEPLOY_TOKEN:-}" ]; then
+            if [ -n "${FIREBASE_PROJECT:-}" ]; then
+              firebase deploy --only hosting --project "${FIREBASE_PROJECT}" --token "${FIREBASE_DEPLOY_TOKEN}"
+            else
+              firebase deploy --only hosting --token "${FIREBASE_DEPLOY_TOKEN}"
+            fi
+          else
+            if [ -n "${FIREBASE_PROJECT:-}" ]; then
+              firebase deploy --only hosting --project "${FIREBASE_PROJECT}"
+            else
+              firebase deploy --only hosting
+            fi
+          fi

--- a/TASKS.md
+++ b/TASKS.md
@@ -1,0 +1,15 @@
+# Deployment Fix Tasks
+
+## 1. Provide Firebase credentials
+- [ ] Preferred: Open the Firebase project in the Google Cloud console, locate (or create) a service account with **Firebase Hosting Admin** and **Service Account Token Creator** roles, generate a JSON key, and store it verbatim in the `FIREBASE_SERVICE_ACCOUNT_KEY` repository secret (or upload a base64-encoded copy as `FIREBASE_SERVICE_ACCOUNT_KEY_BASE64` if your secret manager rejects multiline values).
+- [ ] Legacy fallback: If you cannot provision a service account yet, run `firebase login:ci` locally (or `npm run firebase:token`) and upload the generated token as `FIREBASE_DEPLOY_TOKEN`.
+- [ ] Re-run the "Deploy to Firebase Hosting" workflow and confirm the `Configure Firebase credentials` step detects either credential type, reports the resolved Firebase project ID, and succeeds.
+
+## 2. Verify Node.js 20 compatibility
+- [ ] Re-run the deploy workflow after updating the secret.
+- [ ] Confirm the `Set up Node.js` step now installs Node 20 without `EBADENGINE` warnings from Firebase packages and that the deploy step invokes `firebase deploy --project <project_id>` when the service account is supplied.
+- [ ] Validate the Expo build, tests, and Firebase deploy steps still complete successfully.
+
+## 3. Monitor follow-up maintenance
+- [ ] Run `npm audit` locally and address high-severity vulnerabilities as needed.
+- [ ] Consider pruning deprecated dependencies (e.g., `glob@7`, `uuid@3`, `rimraf@3`) during a scheduled dependency update.

--- a/football-app/README.md
+++ b/football-app/README.md
@@ -130,9 +130,9 @@ secret (for example, `FIREBASE_DEPLOY_TOKEN`):
 
 - A `Deploy to Firebase Hosting` workflow lives at `.github/workflows/deploy-firebase.yml`.
 - It runs on pushes to `main` and can also be invoked manually through the **Run workflow** button.
-- Populate the `FIREBASE_SERVICE_ACCOUNT_KEY` repository secret with a Firebase service account JSON key that has Hosting permissions. The workflow materialises this secret to a temporary file and exports it via `GOOGLE_APPLICATION_CREDENTIALS` so the Firebase CLI can authenticate non-interactively.
+- Populate the `FIREBASE_SERVICE_ACCOUNT_KEY` repository secret with a Firebase service account JSON key that has Hosting permissions. Grant the service account at least the **Firebase Hosting Admin** and **Service Account Token Creator** roles before exporting the key so the deploy step can mint access tokens. If your secret manager struggles with multiline values, store a base64-encoded version of the JSON in `FIREBASE_SERVICE_ACCOUNT_KEY_BASE64` instead. The workflow materialises whichever secret is present to a temporary file, exports it via both `GOOGLE_APPLICATION_CREDENTIALS` and `FIREBASE_SERVICE_ACCOUNT`, and forwards the derived project identifier to the deploy step so the Firebase CLI can authenticate non-interactively. If you are still relying on legacy CI tokens, you can instead provide a `FIREBASE_DEPLOY_TOKEN` secret—the workflow falls back to `firebase deploy --token <value>` only when no service account key is available.
 - The workflow installs dependencies, runs the existing tests, exports the Expo web build, and deploys it to Firebase Hosting using the same helper scripts that are available locally.
-- If the deploy step fails with authentication errors, re-generate the service account key from **Project Settings → Service Accounts → Generate new private key**, update the `FIREBASE_SERVICE_ACCOUNT_KEY` secret, and re-run the workflow.
+- If the deploy step fails with authentication errors, re-generate the service account key from **Project Settings → Service Accounts → Generate new private key**, update the `FIREBASE_SERVICE_ACCOUNT_KEY` secret (or refresh the `FIREBASE_DEPLOY_TOKEN`), and re-run the workflow.
 
 ## Project Structure
 


### PR DESCRIPTION
## Summary
- ensure the deploy workflow reads Firebase secrets via environment variables before invoking the validation helper and logs which auth path is used
- document the required Firebase Hosting roles in the deployment guide so service account keys are provisioned with the right permissions
- export validated Firebase service-account credentials via GOOGLE_APPLICATION_CREDENTIALS and FIREBASE_SERVICE_ACCOUNT, record the resolved project ID, and always pass it to `firebase deploy`

## Testing
- node .github/scripts/validate-firebase-credentials.cjs

------
https://chatgpt.com/codex/tasks/task_e_68e4411090f0832ea33ae90efb9fab2c