### PR TITLE
Fix Firebase credentials env block quoting

### DIFF
--- a/.github/workflows/deploy-firebase.yml
+++ b/.github/workflows/deploy-firebase.yml
@@ -69,9 +69,9 @@ jobs:
             fi
 
             {
-              echo "FIREBASE_SERVICE_ACCOUNT<<'EOF'"
+              echo "FIREBASE_SERVICE_ACCOUNT<<EOF"
               cat "${credentials_path}"
-              echo 'EOF'
+              echo "EOF"
             } >> "$GITHUB_ENV"
 
             echo "FIREBASE_PROJECT=${project_id}" >> "$GITHUB_ENV"


### PR DESCRIPTION
## Summary
- fix the Firebase credential configuration step to use a valid heredoc delimiter when writing to `$GITHUB_ENV`

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68e44f7068d8832ea0993b040f135708