### PR TITLE
Ensure Firebase env heredoc closes on new line

### DIFF
--- a/.github/workflows/deploy-firebase.yml
+++ b/.github/workflows/deploy-firebase.yml
@@ -71,6 +71,7 @@ jobs:
             {
               echo "FIREBASE_SERVICE_ACCOUNT<<'EOF'"
               cat "${credentials_path}"
+              echo
               echo 'EOF'
             } >> "$GITHUB_ENV"
 


### PR DESCRIPTION
## Summary
- ensure the FIREBASE_SERVICE_ACCOUNT heredoc adds an explicit blank line before the EOF delimiter so GitHub can parse the credentials block without errors

## Testing
- npm install
- npm test
- npm run deploy:web

------
https://chatgpt.com/codex/tasks/task_e_68e44f7068d8832ea0993b040f135708