### PR TITLE
Fix Expo web bootstrapping

### DIFF
--- a/football-app/App.tsx
+++ b/football-app/App.tsx
@@ -1,0 +1,1 @@
+export { default } from './src/App';


### PR DESCRIPTION
## Summary
- ensure the App component registers itself with AppRegistry on web so the Expo export mounts instead of rendering a blank page
- add a lightweight App.tsx shim at the project root so Expo's AppEntry can consistently resolve the main component

## Testing
- npm test -- --watch=false
- npm run deploy:web

------
https://chatgpt.com/codex/tasks/task_e_68e44fa2103c832e968013a603123d6f