### PR TITLE
Fix create team navigation handling

### DIFF
--- a/football-app/src/screens/CreateTeamScreen.tsx
+++ b/football-app/src/screens/CreateTeamScreen.tsx
@@ -28,23 +28,22 @@ const CreateTeamScreen: React.FC = () => {
       return;
     }
 
+    const teamName = trimmedName;
+    const teamMembers = members;
+
     dispatch(
       addTeam({
         id: `${Date.now()}`,
-        name: trimmedName,
-        members,
+        name: teamName,
+        members: teamMembers,
       }),
     );
 
-    Alert.alert('Team created', `${trimmedName} has been added to your teams.`, [
-      {
-        text: 'OK',
-        onPress: () => navigation.navigate('Team'),
-      },
-    ]);
-
     setName('');
     setMembersText('');
+
+    navigation.navigate('Team');
+    Alert.alert('Team created', `${teamName} has been added to your teams.`);
   };
 
   return (


### PR DESCRIPTION
## Summary
- ensure newly created teams store trimmed form values before clearing inputs
- navigate back to the teams screen immediately after saving and show a confirmation alert that works across platforms

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e45a23cec0832e9b0c93f8fcab7802