### PR TITLE
Add editable profile settings with persistence

### DIFF
--- a/football-app/src/services/profileStorage.ts
+++ b/football-app/src/services/profileStorage.ts
@@ -1,0 +1,36 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+import type { ProfileState } from '../store/slices/profileSlice';
+
+const STORAGE_KEY = '@footballapp/profile';
+
+export const loadStoredProfile = async (): Promise<ProfileState | null> => {
+  try {
+    const rawValue = await AsyncStorage.getItem(STORAGE_KEY);
+    if (!rawValue) {
+      return null;
+    }
+
+    const parsed: ProfileState = JSON.parse(rawValue);
+    return parsed;
+  } catch (error) {
+    console.warn('Unable to load profile from storage', error);
+    return null;
+  }
+};
+
+export const persistProfile = async (profile: ProfileState): Promise<void> => {
+  try {
+    await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(profile));
+  } catch (error) {
+    console.warn('Unable to persist profile information', error);
+  }
+};
+
+export const clearStoredProfile = async (): Promise<void> => {
+  try {
+    await AsyncStorage.removeItem(STORAGE_KEY);
+  } catch (error) {
+    console.warn('Unable to remove stored profile information', error);
+  }
+};

--- a/football-app/src/store/index.ts
+++ b/football-app/src/store/index.ts
@@ -3,12 +3,14 @@ import { configureStore } from '@reduxjs/toolkit';
 import teamsReducer from './slices/teamsSlice';
 import walletReducer from './slices/walletSlice';
 import premiumReducer from './slices/premiumSlice';
+import profileReducer from './slices/profileSlice';
 
 export const store = configureStore({
   reducer: {
     teams: teamsReducer,
     wallet: walletReducer,
     premium: premiumReducer,
+    profile: profileReducer,
 
   },
 });

--- a/football-app/src/store/slices/profileSlice.ts
+++ b/football-app/src/store/slices/profileSlice.ts
@@ -1,0 +1,86 @@
+import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
+
+export interface ProfileAddress {
+  line1: string;
+  line2: string;
+  city: string;
+  state: string;
+  postalCode: string;
+  country: string;
+}
+
+export interface ProfileSocialLinks {
+  twitter: string;
+  instagram: string;
+  facebook: string;
+  twitch: string;
+  youtube: string;
+  website: string;
+}
+
+export interface ProfileState {
+  fullName: string;
+  displayName: string;
+  dateOfBirth: string;
+  bio: string;
+  address: ProfileAddress;
+  social: ProfileSocialLinks;
+}
+
+export type ProfileUpdate = Partial<Omit<ProfileState, 'address' | 'social'>> & {
+  address?: Partial<ProfileAddress>;
+  social?: Partial<ProfileSocialLinks>;
+};
+
+const initialState: ProfileState = {
+  fullName: '',
+  displayName: '',
+  dateOfBirth: '',
+  bio: '',
+  address: {
+    line1: '',
+    line2: '',
+    city: '',
+    state: '',
+    postalCode: '',
+    country: '',
+  },
+  social: {
+    twitter: '',
+    instagram: '',
+    facebook: '',
+    twitch: '',
+    youtube: '',
+    website: '',
+  },
+};
+
+const mergeProfileState = (current: ProfileState, updates: ProfileUpdate): ProfileState => ({
+  ...current,
+  ...updates,
+  address: {
+    ...current.address,
+    ...(updates.address ?? {}),
+  },
+  social: {
+    ...current.social,
+    ...(updates.social ?? {}),
+  },
+});
+
+const profileSlice = createSlice({
+  name: 'profile',
+  initialState,
+  reducers: {
+    hydrateProfile: (_state, action: PayloadAction<ProfileState>) =>
+      mergeProfileState(initialState, action.payload),
+    updateProfile: (state, action: PayloadAction<ProfileUpdate>) =>
+      mergeProfileState(state, action.payload),
+    resetProfile: () => initialState,
+  },
+});
+
+export const { hydrateProfile, updateProfile, resetProfile } = profileSlice.actions;
+export { initialState as initialProfileState };
+
+export default profileSlice.reducer;


### PR DESCRIPTION
## Summary
- add a profile slice to manage editable account information and persist it locally
- extend the profile screen with a full form for personal, address, and social details plus save handling
- hydrate the UI from stored data so settings survive app restarts

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e4598bb058832eaaf521b96b3a07b0