### PR TITLE
Fix blank Firebase deployment by importing AppRegistry

### DIFF
--- a/football-app/src/App.tsx
+++ b/football-app/src/App.tsx
@@ -2,7 +2,7 @@ import React, { useEffect } from 'react';
 import { NavigationContainer } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { Provider } from 'react-redux';
-import { Platform } from 'react-native';
+import { AppRegistry, Platform } from 'react-native';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 
 


### PR DESCRIPTION
## Summary
- import AppRegistry from react-native when bootstrapping the web app
- ensure the Expo web entry registers the application before running it

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e45ba55a28832ebf4b8040184c2663