### PR TITLE
Add authentication flow and admin centre

### DIFF
--- a/football-app/src/App.tsx
+++ b/football-app/src/App.tsx
@@ -2,9 +2,8 @@ import React, { useEffect } from 'react';
 import { NavigationContainer } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { Provider } from 'react-redux';
-import { AppRegistry, Platform } from 'react-native';
+import { AppRegistry, Platform, ActivityIndicator, View, Text, StyleSheet } from 'react-native';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
-
 
 import HomeScreen from './screens/HomeScreen';
 import TeamScreen from './screens/TeamScreen';
@@ -12,12 +11,16 @@ import CreateTeamScreen from './screens/CreateTeamScreen';
 import ManageTeamScreen from './screens/ManageTeamScreen';
 import TournamentScreen from './screens/TournamentScreen';
 import ProfileScreen from './screens/ProfileScreen';
+import LoginScreen from './screens/LoginScreen';
+import RegisterScreen from './screens/RegisterScreen';
+import AdminDashboardScreen from './screens/AdminDashboardScreen';
 import { store } from './store';
 import { RootStackParamList } from './types/navigation';
-import { useAppDispatch } from './store/hooks';
+import { useAppDispatch, useAppSelector } from './store/hooks';
 import { hydratePremium } from './store/slices/premiumSlice';
 import { loadPremiumEntitlement } from './services/premiumStorage';
-
+import { initializeAuth, selectCurrentUser } from './store/slices/authSlice';
+import { initializeAdmin, selectAdminInitialized } from './store/slices/adminSlice';
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
 
@@ -36,6 +39,69 @@ const PremiumBootstrapper = () => {
   }, [dispatch]);
 
   return null;
+};
+
+const RootNavigator = () => {
+  const dispatch = useAppDispatch();
+  const currentUser = useAppSelector(selectCurrentUser);
+  const authInitialized = useAppSelector((state) => state.auth.initialized);
+  const adminInitialized = useAppSelector(selectAdminInitialized);
+
+  useEffect(() => {
+    if (!authInitialized) {
+      dispatch(initializeAuth());
+    }
+  }, [dispatch, authInitialized]);
+
+  useEffect(() => {
+    if (!adminInitialized) {
+      dispatch(initializeAdmin());
+    }
+  }, [dispatch, adminInitialized]);
+
+  if (!authInitialized) {
+    return (
+      <View style={styles.loadingContainer}>
+        <ActivityIndicator size="large" color="#2563eb" />
+        <Text style={styles.loadingText}>Preparing your football experience…</Text>
+      </View>
+    );
+  }
+
+  return (
+    <Stack.Navigator>
+      {currentUser ? (
+        <>
+          <Stack.Screen name="Home" component={HomeScreen} />
+          <Stack.Screen name="Team" component={TeamScreen} />
+          <Stack.Screen name="CreateTeam" component={CreateTeamScreen} />
+          <Stack.Screen name="ManageTeam" component={ManageTeamScreen} options={{ title: 'Manage Team' }} />
+          <Stack.Screen name="Tournaments" component={TournamentScreen} />
+          <Stack.Screen name="Profile" component={ProfileScreen} />
+          {currentUser.role === 'admin' && (
+            <Stack.Screen
+              name="AdminDashboard"
+              component={AdminDashboardScreen}
+              options={{ title: 'Admin Centre' }}
+            />
+          )}
+        </>
+      ) : (
+        <>
+          <Stack.Screen
+            name="Login"
+            component={LoginScreen}
+            options={{ headerShown: false }}
+          />
+          <Stack.Screen
+            name="Register"
+            component={RegisterScreen}
+            options={{ title: 'Create Account' }}
+          />
+        </>
+      )}
+    </Stack.Navigator>
+  );
 };
 
 const App = () => {
@@ -63,20 +129,27 @@ const App = () => {
       <SafeAreaProvider>
         <PremiumBootstrapper />
         <NavigationContainer>
-          <Stack.Navigator initialRouteName="Home">
-            <Stack.Screen name="Home" component={HomeScreen} />
-            <Stack.Screen name="Team" component={TeamScreen} />
-            <Stack.Screen name="CreateTeam" component={CreateTeamScreen} />
-            <Stack.Screen name="ManageTeam" component={ManageTeamScreen} options={{ title: 'Manage Team' }} />
-            <Stack.Screen name="Tournaments" component={TournamentScreen} />
-            <Stack.Screen name="Profile" component={ProfileScreen} />
-          </Stack.Navigator>
+          <RootNavigator />
         </NavigationContainer>
       </SafeAreaProvider>
-
     </Provider>
   );
 };
+
+const styles = StyleSheet.create({
+  loadingContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: '#f3f4f6',
+  },
+  loadingText: {
+    marginTop: 16,
+    fontSize: 16,
+    color: '#1f2937',
+    textAlign: 'center',
+  },
+});
 
 if (Platform.OS === 'web') {
   const applicationName = 'main';

--- a/football-app/src/screens/AdminDashboardScreen.tsx
+++ b/football-app/src/screens/AdminDashboardScreen.tsx
@@ -1,0 +1,830 @@
+import React, { useCallback, useMemo, useState } from 'react';
+import {
+  ActivityIndicator,
+  Alert,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { SafeAreaView } from 'react-native-safe-area-context';
+
+import { RootStackParamList } from '../types/navigation';
+import { useAppDispatch, useAppSelector } from '../store/hooks';
+import {
+  selectCurrentUser,
+  selectUsers,
+  toggleUserStatus,
+  updateMarketingPreference,
+} from '../store/slices/authSlice';
+import {
+  addMarketingCampaign,
+  markCampaignAsSent,
+  recordManualPayment,
+  selectAdminError,
+  selectAdminInitialized,
+  selectAdminLoading,
+  selectMarketingCampaigns,
+  selectPayments,
+  updatePaymentStatus,
+} from '../store/slices/adminSlice';
+import type { MarketingAudience, PaymentStatus } from '../types/admin';
+
+interface AdminDashboardScreenProps {
+  navigation: NativeStackNavigationProp<RootStackParamList, 'AdminDashboard'>;
+}
+
+const paymentStatuses: PaymentStatus[] = ['pending', 'completed', 'failed'];
+const marketingAudiences: MarketingAudience[] = ['all', 'premium', 'free'];
+
+const AdminDashboardScreen: React.FC<AdminDashboardScreenProps> = ({ navigation }) => {
+  const dispatch = useAppDispatch();
+  const currentUser = useAppSelector(selectCurrentUser);
+  const users = useAppSelector(selectUsers);
+  const payments = useAppSelector(selectPayments);
+  const campaigns = useAppSelector(selectMarketingCampaigns);
+  const adminLoading = useAppSelector(selectAdminLoading);
+  const adminInitialized = useAppSelector(selectAdminInitialized);
+  const adminError = useAppSelector(selectAdminError);
+
+  const [updatingUserId, setUpdatingUserId] = useState<string | null>(null);
+  const [updatingMarketingUserId, setUpdatingMarketingUserId] = useState<string | null>(null);
+  const [updatingPaymentId, setUpdatingPaymentId] = useState<string | null>(null);
+  const [updatingCampaignId, setUpdatingCampaignId] = useState<string | null>(null);
+  const [recordingPayment, setRecordingPayment] = useState(false);
+  const [creatingCampaign, setCreatingCampaign] = useState(false);
+
+  const [paymentEmail, setPaymentEmail] = useState('');
+  const [paymentAmount, setPaymentAmount] = useState('');
+  const [paymentCurrency, setPaymentCurrency] = useState('USD');
+  const [paymentNotes, setPaymentNotes] = useState('');
+  const [paymentStatus, setPaymentStatus] = useState<PaymentStatus>('completed');
+
+  const [campaignTitle, setCampaignTitle] = useState('');
+  const [campaignAudience, setCampaignAudience] = useState<MarketingAudience>('all');
+  const [campaignScheduledFor, setCampaignScheduledFor] = useState('');
+  const [campaignNotes, setCampaignNotes] = useState('');
+
+  const metrics = useMemo(() => {
+    const activeUsers = users.filter((user) => user.status === 'active').length;
+    const suspendedUsers = users.filter((user) => user.status === 'suspended').length;
+    const marketingOptIns = users.filter((user) => user.marketingOptIn).length;
+    const completedPayments = payments.filter((payment) => payment.status === 'completed');
+    const totalRevenue = completedPayments.reduce((sum, payment) => sum + payment.amount, 0);
+    const pendingPayments = payments.filter((payment) => payment.status === 'pending').length;
+
+    return {
+      activeUsers,
+      suspendedUsers,
+      marketingOptIns,
+      totalRevenue,
+      pendingPayments,
+    };
+  }, [payments, users]);
+
+  const handleToggleUserStatus = useCallback(
+    async (userId: string) => {
+      setUpdatingUserId(userId);
+      try {
+        await dispatch(toggleUserStatus({ userId })).unwrap();
+      } catch (error) {
+        const message = typeof error === 'string' ? error : 'Unable to update user status.';
+        Alert.alert('Update failed', message);
+      } finally {
+        setUpdatingUserId(null);
+      }
+    },
+    [dispatch],
+  );
+
+  const handleMarketingPreference = useCallback(
+    async (userId: string, marketingOptIn: boolean) => {
+      setUpdatingMarketingUserId(userId);
+      try {
+        await dispatch(updateMarketingPreference({ userId, marketingOptIn })).unwrap();
+      } catch (error) {
+        const message = typeof error === 'string' ? error : 'Unable to update marketing preference.';
+        Alert.alert('Update failed', message);
+      } finally {
+        setUpdatingMarketingUserId(null);
+      }
+    },
+    [dispatch],
+  );
+
+  const handleUpdatePaymentStatus = useCallback(
+    async (paymentId: string, status: PaymentStatus) => {
+      setUpdatingPaymentId(paymentId);
+      try {
+        await dispatch(updatePaymentStatus({ paymentId, status })).unwrap();
+      } catch (error) {
+        const message = typeof error === 'string' ? error : 'Unable to update payment status.';
+        Alert.alert('Update failed', message);
+      } finally {
+        setUpdatingPaymentId(null);
+      }
+    },
+    [dispatch],
+  );
+
+  const handleRecordPayment = useCallback(async () => {
+    const amount = Number(paymentAmount);
+    if (!Number.isFinite(amount) || amount <= 0) {
+      Alert.alert('Invalid amount', 'Enter a valid payment amount greater than zero.');
+      return;
+    }
+
+    setRecordingPayment(true);
+    try {
+      await dispatch(
+        recordManualPayment({
+          userEmail: paymentEmail,
+          amount,
+          currency: paymentCurrency.trim().toUpperCase() || 'USD',
+          status: paymentStatus,
+          notes: paymentNotes.trim() || undefined,
+        }),
+      ).unwrap();
+
+      setPaymentEmail('');
+      setPaymentAmount('');
+      setPaymentCurrency('USD');
+      setPaymentNotes('');
+      setPaymentStatus('completed');
+    } catch (error) {
+      const message = typeof error === 'string' ? error : 'Unable to record payment.';
+      Alert.alert('Payment error', message);
+    } finally {
+      setRecordingPayment(false);
+    }
+  }, [dispatch, paymentAmount, paymentCurrency, paymentEmail, paymentNotes, paymentStatus]);
+
+  const handleCreateCampaign = useCallback(async () => {
+    if (!campaignTitle.trim()) {
+      Alert.alert('Missing information', 'Campaign title is required.');
+      return;
+    }
+
+    setCreatingCampaign(true);
+    try {
+      await dispatch(
+        addMarketingCampaign({
+          title: campaignTitle,
+          audience: campaignAudience,
+          scheduledFor: campaignScheduledFor.trim() || undefined,
+          notes: campaignNotes.trim() || undefined,
+        }),
+      ).unwrap();
+
+      setCampaignTitle('');
+      setCampaignNotes('');
+      setCampaignScheduledFor('');
+      setCampaignAudience('all');
+    } catch (error) {
+      const message = typeof error === 'string' ? error : 'Unable to create campaign.';
+      Alert.alert('Campaign error', message);
+    } finally {
+      setCreatingCampaign(false);
+    }
+  }, [campaignAudience, campaignNotes, campaignScheduledFor, campaignTitle, dispatch]);
+
+  const handleMarkCampaignSent = useCallback(
+    async (campaignId: string) => {
+      setUpdatingCampaignId(campaignId);
+      try {
+        await dispatch(markCampaignAsSent({ campaignId })).unwrap();
+      } catch (error) {
+        const message = typeof error === 'string' ? error : 'Unable to update campaign status.';
+        Alert.alert('Campaign error', message);
+      } finally {
+        setUpdatingCampaignId(null);
+      }
+    },
+    [dispatch],
+  );
+
+  if (!currentUser || currentUser.role !== 'admin') {
+    return (
+      <SafeAreaView style={styles.safeArea}>
+        <View style={styles.unauthorisedContainer}>
+          <Text style={styles.unauthorisedTitle}>Access restricted</Text>
+          <Text style={styles.unauthorisedText}>
+            You need an admin account to view the management centre.
+          </Text>
+          <TouchableOpacity style={styles.backButton} onPress={() => navigation.navigate('Home')}>
+            <Text style={styles.backButtonText}>Go back</Text>
+          </TouchableOpacity>
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  if (!adminInitialized || adminLoading) {
+    return (
+      <SafeAreaView style={styles.safeArea}>
+        <View style={styles.loadingContainer}>
+          <ActivityIndicator size="large" color="#2563eb" />
+          <Text style={styles.loadingText}>Loading admin data…</Text>
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  return (
+    <SafeAreaView style={styles.safeArea}>
+      <ScrollView contentContainerStyle={styles.scrollContent}>
+        <Text style={styles.screenTitle}>Admin centre</Text>
+        <Text style={styles.screenSubtitle}>
+          Manage accounts, payments, and marketing touchpoints for your football community.
+        </Text>
+
+        {adminError ? <Text style={styles.errorText}>{adminError}</Text> : null}
+
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>User management</Text>
+          <View style={styles.metricsRow}>
+            <View style={styles.metricCard}>
+              <Text style={styles.metricValue}>{metrics.activeUsers}</Text>
+              <Text style={styles.metricLabel}>Active users</Text>
+            </View>
+            <View style={styles.metricCard}>
+              <Text style={styles.metricValue}>{metrics.suspendedUsers}</Text>
+              <Text style={styles.metricLabel}>Suspended</Text>
+            </View>
+            <View style={styles.metricCard}>
+              <Text style={styles.metricValue}>{metrics.marketingOptIns}</Text>
+              <Text style={styles.metricLabel}>Marketing opt-ins</Text>
+            </View>
+          </View>
+
+          {users.map((user) => (
+            <View key={user.id} style={styles.card}>
+              <View style={styles.cardHeader}>
+                <Text style={styles.cardTitle}>{user.fullName}</Text>
+                <Text
+                  style={[
+                    styles.badge,
+                    user.role === 'admin' ? styles.badgeAdmin : styles.badgeUser,
+                  ]}
+                >
+                  {user.role.toUpperCase()}
+                </Text>
+              </View>
+              <Text style={styles.cardDetail}>{user.email}</Text>
+              <Text style={styles.cardDetail}>Joined {new Date(user.createdAt).toLocaleDateString()}</Text>
+              <Text style={styles.cardDetail}>
+                Status:{' '}
+                <Text style={user.status === 'active' ? styles.statusActive : styles.statusSuspended}>
+                  {user.status}
+                </Text>
+              </Text>
+              <Text style={styles.cardDetail}>
+                Marketing opt-in: {user.marketingOptIn ? 'Enabled' : 'Disabled'}
+              </Text>
+              <View style={styles.cardActions}>
+                <TouchableOpacity
+                  style={[styles.actionButton, styles.outlineButton]}
+                  onPress={() => handleMarketingPreference(user.id, !user.marketingOptIn)}
+                  disabled={updatingMarketingUserId === user.id}
+                >
+                  <Text style={styles.outlineButtonText}>
+                    {updatingMarketingUserId === user.id
+                      ? 'Updating…'
+                      : user.marketingOptIn
+                      ? 'Disable marketing'
+                      : 'Enable marketing'}
+                  </Text>
+                </TouchableOpacity>
+                <TouchableOpacity
+                  style={[styles.actionButton, styles.destructiveButton]}
+                  onPress={() => handleToggleUserStatus(user.id)}
+                  disabled={user.role === 'admin' || updatingUserId === user.id}
+                >
+                  <Text style={styles.destructiveText}>
+                    {user.role === 'admin'
+                      ? 'Admin protected'
+                      : updatingUserId === user.id
+                      ? 'Updating…'
+                      : user.status === 'active'
+                      ? 'Suspend'
+                      : 'Activate'}
+                  </Text>
+                </TouchableOpacity>
+              </View>
+            </View>
+          ))}
+        </View>
+
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>Payments</Text>
+          <View style={styles.metricsRow}>
+            <View style={styles.metricCard}>
+              <Text style={styles.metricValue}>{metrics.pendingPayments}</Text>
+              <Text style={styles.metricLabel}>Pending</Text>
+            </View>
+            <View style={styles.metricCard}>
+              <Text style={styles.metricValue}>
+                ${metrics.totalRevenue.toFixed(2)}
+              </Text>
+              <Text style={styles.metricLabel}>Completed revenue</Text>
+            </View>
+          </View>
+
+          <View style={styles.card}>
+            <Text style={styles.cardTitle}>Record manual payment</Text>
+            <Text style={styles.cardDetail}>Add offline payments or adjustments.</Text>
+            <View style={styles.inlineFieldGroup}>
+              <View style={styles.inlineField}>
+                <Text style={styles.inlineLabel}>Email</Text>
+                <TextInput
+                  style={styles.input}
+                  value={paymentEmail}
+                  onChangeText={setPaymentEmail}
+                  autoCapitalize="none"
+                  keyboardType="email-address"
+                  placeholder="fan@club.com"
+                />
+              </View>
+              <View style={styles.inlineFieldSmall}>
+                <Text style={styles.inlineLabel}>Amount</Text>
+                <TextInput
+                  style={styles.input}
+                  value={paymentAmount}
+                  onChangeText={setPaymentAmount}
+                  keyboardType="decimal-pad"
+                  placeholder="49.99"
+                />
+              </View>
+              <View style={styles.inlineFieldTiny}>
+                <Text style={styles.inlineLabel}>Currency</Text>
+                <TextInput
+                  style={styles.input}
+                  value={paymentCurrency}
+                  onChangeText={(value) => setPaymentCurrency(value.toUpperCase())}
+                  autoCapitalize="characters"
+                  maxLength={3}
+                />
+              </View>
+            </View>
+            <View style={styles.fieldGroup}>
+              <Text style={styles.inlineLabel}>Notes</Text>
+              <TextInput
+                style={[styles.input, styles.multilineInput]}
+                value={paymentNotes}
+                onChangeText={setPaymentNotes}
+                placeholder="Add context for this payment"
+                multiline
+              />
+            </View>
+            <View style={styles.chipRow}>
+              {paymentStatuses.map((status) => (
+                <TouchableOpacity
+                  key={status}
+                  style={[styles.chip, paymentStatus === status && styles.chipActive]}
+                  onPress={() => setPaymentStatus(status)}
+                >
+                  <Text
+                    style={[
+                      styles.chipText,
+                      paymentStatus === status && styles.chipTextActive,
+                    ]}
+                  >
+                    {status}
+                  </Text>
+                </TouchableOpacity>
+              ))}
+            </View>
+            <TouchableOpacity
+              style={[styles.actionButton, styles.primaryButton]}
+              onPress={handleRecordPayment}
+              disabled={recordingPayment}
+            >
+              <Text style={styles.primaryButtonText}>
+                {recordingPayment ? 'Recording…' : 'Record payment'}
+              </Text>
+            </TouchableOpacity>
+          </View>
+
+          {payments.map((payment) => (
+            <View key={payment.id} style={styles.card}>
+              <View style={styles.cardHeader}>
+                <Text style={styles.cardTitle}>{payment.userEmail}</Text>
+                <Text
+                  style={[
+                    styles.badge,
+                    payment.status === 'completed'
+                      ? styles.badgeSuccess
+                      : payment.status === 'pending'
+                      ? styles.badgeWarning
+                      : styles.badgeDanger,
+                  ]}
+                >
+                  {payment.status.toUpperCase()}
+                </Text>
+              </View>
+              <Text style={styles.cardDetail}>
+                Amount {payment.amount.toFixed(2)} {payment.currency}
+              </Text>
+              <Text style={styles.cardDetail}>
+                Recorded {new Date(payment.recordedAt).toLocaleString()}
+              </Text>
+              {payment.notes ? (
+                <Text style={styles.cardDetail}>Notes: {payment.notes}</Text>
+              ) : null}
+              <View style={styles.chipRow}>
+                {paymentStatuses.map((status) => (
+                  <TouchableOpacity
+                    key={status}
+                    style={[
+                      styles.chip,
+                      payment.status === status && styles.chipActive,
+                    ]}
+                    onPress={() => handleUpdatePaymentStatus(payment.id, status)}
+                    disabled={updatingPaymentId === payment.id}
+                  >
+                    <Text
+                      style={[
+                        styles.chipText,
+                        payment.status === status && styles.chipTextActive,
+                      ]}
+                    >
+                      {updatingPaymentId === payment.id && payment.status !== status
+                        ? '…'
+                        : status}
+                    </Text>
+                  </TouchableOpacity>
+                ))}
+              </View>
+            </View>
+          ))}
+        </View>
+
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>Marketing campaigns</Text>
+          <View style={styles.card}>
+            <Text style={styles.cardTitle}>Launch campaign</Text>
+            <View style={styles.fieldGroup}>
+              <Text style={styles.inlineLabel}>Title</Text>
+              <TextInput
+                style={styles.input}
+                value={campaignTitle}
+                onChangeText={setCampaignTitle}
+                placeholder="Summer five-a-side blitz"
+              />
+            </View>
+            <View style={styles.chipRow}>
+              {marketingAudiences.map((audience) => (
+                <TouchableOpacity
+                  key={audience}
+                  style={[styles.chip, campaignAudience === audience && styles.chipActive]}
+                  onPress={() => setCampaignAudience(audience)}
+                >
+                  <Text
+                    style={[
+                      styles.chipText,
+                      campaignAudience === audience && styles.chipTextActive,
+                    ]}
+                  >
+                    {audience}
+                  </Text>
+                </TouchableOpacity>
+              ))}
+            </View>
+            <View style={styles.fieldGroup}>
+              <Text style={styles.inlineLabel}>Scheduled for</Text>
+              <TextInput
+                style={styles.input}
+                value={campaignScheduledFor}
+                onChangeText={setCampaignScheduledFor}
+                placeholder="YYYY-MM-DD"
+              />
+            </View>
+            <View style={styles.fieldGroup}>
+              <Text style={styles.inlineLabel}>Notes</Text>
+              <TextInput
+                style={[styles.input, styles.multilineInput]}
+                value={campaignNotes}
+                onChangeText={setCampaignNotes}
+                placeholder="What channels will you use?"
+                multiline
+              />
+            </View>
+            <TouchableOpacity
+              style={[styles.actionButton, styles.primaryButton]}
+              onPress={handleCreateCampaign}
+              disabled={creatingCampaign}
+            >
+              <Text style={styles.primaryButtonText}>
+                {creatingCampaign ? 'Scheduling…' : 'Create campaign'}
+              </Text>
+            </TouchableOpacity>
+          </View>
+
+          {campaigns.map((campaign) => (
+            <View key={campaign.id} style={styles.card}>
+              <View style={styles.cardHeader}>
+                <Text style={styles.cardTitle}>{campaign.title}</Text>
+                <Text
+                  style={[
+                    styles.badge,
+                    campaign.status === 'sent'
+                      ? styles.badgeSuccess
+                      : campaign.status === 'scheduled'
+                      ? styles.badgeWarning
+                      : styles.badgeUser,
+                  ]}
+                >
+                  {campaign.status.toUpperCase()}
+                </Text>
+              </View>
+              <Text style={styles.cardDetail}>Audience: {campaign.audience}</Text>
+              <Text style={styles.cardDetail}>
+                Created {new Date(campaign.createdAt).toLocaleString()}
+              </Text>
+              {campaign.scheduledFor ? (
+                <Text style={styles.cardDetail}>
+                  Scheduled for {campaign.scheduledFor}
+                </Text>
+              ) : null}
+              {campaign.sentAt ? (
+                <Text style={styles.cardDetail}>Sent {new Date(campaign.sentAt).toLocaleString()}</Text>
+              ) : null}
+              {campaign.notes ? <Text style={styles.cardDetail}>Notes: {campaign.notes}</Text> : null}
+              {campaign.status !== 'sent' ? (
+                <TouchableOpacity
+                  style={[styles.actionButton, styles.primaryButton]}
+                  onPress={() => handleMarkCampaignSent(campaign.id)}
+                  disabled={updatingCampaignId === campaign.id}
+                >
+                  <Text style={styles.primaryButtonText}>
+                    {updatingCampaignId === campaign.id ? 'Updating…' : 'Mark as sent'}
+                  </Text>
+                </TouchableOpacity>
+              ) : null}
+            </View>
+          ))}
+        </View>
+      </ScrollView>
+    </SafeAreaView>
+  );
+};
+
+const styles = StyleSheet.create({
+  safeArea: {
+    flex: 1,
+    backgroundColor: '#f1f5f9',
+  },
+  scrollContent: {
+    padding: 24,
+    paddingBottom: 48,
+  },
+  screenTitle: {
+    fontSize: 28,
+    fontWeight: '700',
+    color: '#0f172a',
+    marginBottom: 4,
+  },
+  screenSubtitle: {
+    fontSize: 16,
+    color: '#475569',
+    marginBottom: 24,
+  },
+  section: {
+    marginBottom: 32,
+  },
+  sectionTitle: {
+    fontSize: 20,
+    fontWeight: '700',
+    color: '#0f172a',
+    marginBottom: 16,
+  },
+  metricsRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    marginBottom: 16,
+  },
+  metricCard: {
+    backgroundColor: '#fff',
+    borderRadius: 12,
+    padding: 16,
+    marginRight: 12,
+    marginBottom: 12,
+    shadowColor: '#0f172a',
+    shadowOpacity: 0.05,
+    shadowRadius: 8,
+    shadowOffset: { width: 0, height: 2 },
+    elevation: 2,
+    minWidth: 120,
+  },
+  metricValue: {
+    fontSize: 22,
+    fontWeight: '700',
+    color: '#0f172a',
+  },
+  metricLabel: {
+    fontSize: 13,
+    color: '#475569',
+    marginTop: 4,
+  },
+  card: {
+    backgroundColor: '#fff',
+    borderRadius: 12,
+    padding: 16,
+    marginBottom: 16,
+    shadowColor: '#0f172a',
+    shadowOpacity: 0.05,
+    shadowRadius: 8,
+    shadowOffset: { width: 0, height: 2 },
+    elevation: 2,
+  },
+  cardHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 8,
+  },
+  cardTitle: {
+    fontSize: 18,
+    fontWeight: '700',
+    color: '#0f172a',
+  },
+  cardDetail: {
+    color: '#475569',
+    marginBottom: 6,
+  },
+  cardActions: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginTop: 12,
+  },
+  actionButton: {
+    flex: 1,
+    paddingVertical: 12,
+    borderRadius: 8,
+    alignItems: 'center',
+    marginHorizontal: 4,
+  },
+  outlineButton: {
+    borderWidth: 1,
+    borderColor: '#2563eb',
+  },
+  outlineButtonText: {
+    color: '#2563eb',
+    fontWeight: '600',
+  },
+  destructiveButton: {
+    borderWidth: 1,
+    borderColor: '#dc2626',
+  },
+  destructiveText: {
+    color: '#dc2626',
+    fontWeight: '600',
+    textAlign: 'center',
+  },
+  primaryButton: {
+    backgroundColor: '#2563eb',
+  },
+  primaryButtonText: {
+    color: '#f8fafc',
+    fontWeight: '700',
+  },
+  badge: {
+    paddingHorizontal: 10,
+    paddingVertical: 4,
+    borderRadius: 999,
+    fontSize: 12,
+    fontWeight: '700',
+    color: '#0f172a',
+    textTransform: 'uppercase',
+  },
+  badgeAdmin: {
+    backgroundColor: '#fde68a',
+  },
+  badgeUser: {
+    backgroundColor: '#e0f2fe',
+  },
+  badgeSuccess: {
+    backgroundColor: '#bbf7d0',
+  },
+  badgeWarning: {
+    backgroundColor: '#fef08a',
+  },
+  badgeDanger: {
+    backgroundColor: '#fecaca',
+  },
+  statusActive: {
+    color: '#16a34a',
+    fontWeight: '600',
+    textTransform: 'capitalize',
+  },
+  statusSuspended: {
+    color: '#dc2626',
+    fontWeight: '600',
+    textTransform: 'capitalize',
+  },
+  inlineFieldGroup: {
+    flexDirection: 'row',
+    marginTop: 12,
+    marginBottom: 12,
+  },
+  inlineField: {
+    flex: 1,
+    marginRight: 8,
+  },
+  inlineFieldSmall: {
+    width: 120,
+    marginRight: 8,
+  },
+  inlineFieldTiny: {
+    width: 90,
+  },
+  inlineLabel: {
+    fontWeight: '600',
+    color: '#0f172a',
+    marginBottom: 4,
+  },
+  input: {
+    backgroundColor: '#f8fafc',
+    borderRadius: 8,
+    paddingHorizontal: 14,
+    paddingVertical: 10,
+    borderWidth: 1,
+    borderColor: '#cbd5f5',
+    color: '#0f172a',
+  },
+  multilineInput: {
+    minHeight: 70,
+    textAlignVertical: 'top',
+  },
+  chipRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    marginVertical: 12,
+  },
+  chip: {
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 999,
+    borderWidth: 1,
+    borderColor: '#cbd5f5',
+    marginRight: 8,
+    marginBottom: 8,
+  },
+  chipActive: {
+    backgroundColor: '#2563eb',
+    borderColor: '#1d4ed8',
+  },
+  chipText: {
+    color: '#334155',
+    fontWeight: '600',
+    textTransform: 'capitalize',
+  },
+  chipTextActive: {
+    color: '#f8fafc',
+  },
+  loadingContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  loadingText: {
+    marginTop: 16,
+    color: '#475569',
+  },
+  errorText: {
+    color: '#dc2626',
+    marginBottom: 16,
+  },
+  unauthorisedContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: 24,
+  },
+  unauthorisedTitle: {
+    fontSize: 24,
+    fontWeight: '700',
+    color: '#0f172a',
+    marginBottom: 8,
+  },
+  unauthorisedText: {
+    color: '#475569',
+    textAlign: 'center',
+    marginBottom: 16,
+  },
+  backButton: {
+    paddingHorizontal: 24,
+    paddingVertical: 12,
+    backgroundColor: '#2563eb',
+    borderRadius: 8,
+  },
+  backButtonText: {
+    color: '#f8fafc',
+    fontWeight: '700',
+  },
+});
+
+export default AdminDashboardScreen;

--- a/football-app/src/screens/HomeScreen.tsx
+++ b/football-app/src/screens/HomeScreen.tsx
@@ -6,6 +6,8 @@ import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import BannerAdSlot from '../components/BannerAdSlot';
 import { defaultBannerSize, homeBannerAdUnitId } from '../config/ads';
 import { RootStackParamList } from '../types/navigation';
+import { useAppSelector } from '../store/hooks';
+import { selectCurrentUser } from '../store/slices/authSlice';
 
 type HomeScreenNavigationProp = NativeStackNavigationProp<RootStackParamList, 'Home'>;
 
@@ -14,10 +16,17 @@ interface HomeScreenProps {
 }
 
 const HomeScreen: React.FC<HomeScreenProps> = ({ navigation }) => {
+  const currentUser = useAppSelector(selectCurrentUser);
+  const greetingName = currentUser?.fullName.split(' ')[0] ?? 'coach';
+  const welcomeMessage = currentUser
+    ? `Ready for another matchday, ${greetingName}?`
+    : 'Sign in to unlock the full football experience.';
+
   return (
     <SafeAreaView style={styles.safeArea}>
       <View style={styles.content}>
         <Text style={styles.title}>Welcome to the Football App!</Text>
+        <Text style={styles.subtitle}>{welcomeMessage}</Text>
         <View style={styles.buttonGroup}>
           <View style={styles.buttonWrapper}>
             <Button title="Manage Teams" onPress={() => navigation.navigate('Team')} />
@@ -54,6 +63,12 @@ const styles = StyleSheet.create({
     fontSize: 24,
     fontWeight: '700',
     marginBottom: 32,
+    textAlign: 'center',
+  },
+  subtitle: {
+    fontSize: 16,
+    color: '#4b5563',
+    marginBottom: 24,
     textAlign: 'center',
   },
   buttonGroup: {

--- a/football-app/src/screens/LoginScreen.tsx
+++ b/football-app/src/screens/LoginScreen.tsx
@@ -1,0 +1,195 @@
+import React, { useCallback, useState } from 'react';
+import {
+  Alert,
+  KeyboardAvoidingView,
+  Platform,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { SafeAreaView } from 'react-native-safe-area-context';
+
+import { RootStackParamList } from '../types/navigation';
+import { useAppDispatch, useAppSelector } from '../store/hooks';
+import { loginUser, selectAuthLoading } from '../store/slices/authSlice';
+
+interface LoginScreenProps {
+  navigation: NativeStackNavigationProp<RootStackParamList, 'Login'>;
+}
+
+const LoginScreen: React.FC<LoginScreenProps> = ({ navigation }) => {
+  const dispatch = useAppDispatch();
+  const loading = useAppSelector(selectAuthLoading);
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleSubmit = useCallback(async () => {
+    if (!email.trim() || !password.trim()) {
+      Alert.alert('Missing details', 'Please enter both email and password.');
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      await dispatch(loginUser({ email, password })).unwrap();
+    } catch (error) {
+      const message = typeof error === 'string' ? error : 'Unable to sign in. Please try again.';
+      Alert.alert('Login failed', message);
+    } finally {
+      setSubmitting(false);
+    }
+  }, [dispatch, email, password]);
+
+  return (
+    <SafeAreaView style={styles.safeArea}>
+      <KeyboardAvoidingView
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+        style={styles.flex}
+        keyboardVerticalOffset={64}
+      >
+        <ScrollView contentContainerStyle={styles.content} keyboardShouldPersistTaps="handled">
+          <Text style={styles.title}>Welcome back</Text>
+          <Text style={styles.subtitle}>Sign in to manage your teams and competitions.</Text>
+
+          <View style={styles.fieldGroup}>
+            <Text style={styles.label}>Email</Text>
+            <TextInput
+              value={email}
+              onChangeText={setEmail}
+              autoCapitalize="none"
+              keyboardType="email-address"
+              placeholder="you@example.com"
+              style={styles.input}
+              textContentType="emailAddress"
+            />
+          </View>
+
+          <View style={styles.fieldGroup}>
+            <Text style={styles.label}>Password</Text>
+            <TextInput
+              value={password}
+              onChangeText={setPassword}
+              secureTextEntry
+              placeholder="••••••••"
+              style={styles.input}
+              textContentType="password"
+            />
+          </View>
+
+          <TouchableOpacity
+            style={[styles.primaryButton, (loading || submitting) && styles.primaryButtonDisabled]}
+            onPress={handleSubmit}
+            disabled={loading || submitting}
+          >
+            <Text style={styles.primaryButtonText}>
+              {loading || submitting ? 'Signing in…' : 'Sign in'}
+            </Text>
+          </TouchableOpacity>
+
+          <TouchableOpacity onPress={() => navigation.navigate('Register')} style={styles.secondaryAction}>
+            <Text style={styles.secondaryText}>Need an account? Register now</Text>
+          </TouchableOpacity>
+
+          <View style={styles.helpCard}>
+            <Text style={styles.helpTitle}>Admin access</Text>
+            <Text style={styles.helpText}>Use owner@clubhouse.app with password admin123 to access the admin centre.</Text>
+            <Text style={styles.helpText}>Regular demo user: jane@supporters.club / football</Text>
+          </View>
+        </ScrollView>
+      </KeyboardAvoidingView>
+    </SafeAreaView>
+  );
+};
+
+const styles = StyleSheet.create({
+  flex: {
+    flex: 1,
+  },
+  safeArea: {
+    flex: 1,
+    backgroundColor: '#0f172a',
+  },
+  content: {
+    flexGrow: 1,
+    padding: 24,
+    justifyContent: 'center',
+  },
+  title: {
+    fontSize: 28,
+    fontWeight: '700',
+    color: '#f8fafc',
+    marginBottom: 8,
+    textAlign: 'center',
+  },
+  subtitle: {
+    fontSize: 16,
+    color: '#cbd5f5',
+    marginBottom: 24,
+    textAlign: 'center',
+  },
+  fieldGroup: {
+    marginBottom: 16,
+  },
+  label: {
+    color: '#cbd5f5',
+    marginBottom: 8,
+    fontWeight: '600',
+  },
+  input: {
+    backgroundColor: '#1e293b',
+    borderRadius: 8,
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    color: '#f8fafc',
+    borderWidth: 1,
+    borderColor: '#334155',
+  },
+  primaryButton: {
+    backgroundColor: '#2563eb',
+    borderRadius: 8,
+    paddingVertical: 14,
+    alignItems: 'center',
+    marginTop: 8,
+  },
+  primaryButtonDisabled: {
+    opacity: 0.7,
+  },
+  primaryButtonText: {
+    color: '#f8fafc',
+    fontWeight: '700',
+    fontSize: 16,
+  },
+  secondaryAction: {
+    marginTop: 16,
+    alignItems: 'center',
+  },
+  secondaryText: {
+    color: '#93c5fd',
+    fontSize: 15,
+  },
+  helpCard: {
+    marginTop: 32,
+    padding: 16,
+    backgroundColor: '#1e293b',
+    borderRadius: 10,
+    borderWidth: 1,
+    borderColor: '#334155',
+  },
+  helpTitle: {
+    color: '#f8fafc',
+    fontWeight: '700',
+    marginBottom: 8,
+  },
+  helpText: {
+    color: '#cbd5f5',
+    marginBottom: 4,
+    lineHeight: 20,
+  },
+});
+
+export default LoginScreen;

--- a/football-app/src/screens/RegisterScreen.tsx
+++ b/football-app/src/screens/RegisterScreen.tsx
@@ -1,0 +1,246 @@
+import React, { useCallback, useState } from 'react';
+import {
+  Alert,
+  KeyboardAvoidingView,
+  Platform,
+  ScrollView,
+  StyleSheet,
+  Switch,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { SafeAreaView } from 'react-native-safe-area-context';
+
+import { RootStackParamList } from '../types/navigation';
+import { useAppDispatch, useAppSelector } from '../store/hooks';
+import { registerUser, selectAuthLoading } from '../store/slices/authSlice';
+
+interface RegisterScreenProps {
+  navigation: NativeStackNavigationProp<RootStackParamList, 'Register'>;
+}
+
+const RegisterScreen: React.FC<RegisterScreenProps> = ({ navigation }) => {
+  const dispatch = useAppDispatch();
+  const loading = useAppSelector(selectAuthLoading);
+  const [fullName, setFullName] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [marketingOptIn, setMarketingOptIn] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleSubmit = useCallback(async () => {
+    if (!fullName.trim()) {
+      Alert.alert('Missing details', 'Please provide your full name.');
+      return;
+    }
+
+    if (!email.trim()) {
+      Alert.alert('Missing details', 'An email address is required.');
+      return;
+    }
+
+    if (!password.trim() || password.length < 6) {
+      Alert.alert('Weak password', 'Choose a password with at least 6 characters.');
+      return;
+    }
+
+    if (password !== confirmPassword) {
+      Alert.alert('Mismatch', 'Passwords do not match.');
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      await dispatch(registerUser({ fullName, email, password, marketingOptIn })).unwrap();
+    } catch (error) {
+      const message = typeof error === 'string' ? error : 'Unable to create your account right now.';
+      Alert.alert('Registration failed', message);
+    } finally {
+      setSubmitting(false);
+    }
+  }, [confirmPassword, dispatch, email, fullName, marketingOptIn, password]);
+
+  return (
+    <SafeAreaView style={styles.safeArea}>
+      <KeyboardAvoidingView
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+        style={styles.flex}
+        keyboardVerticalOffset={64}
+      >
+        <ScrollView contentContainerStyle={styles.content} keyboardShouldPersistTaps="handled">
+          <Text style={styles.title}>Create your account</Text>
+          <Text style={styles.subtitle}>Join tournaments, manage teams, and unlock premium experiences.</Text>
+
+          <View style={styles.fieldGroup}>
+            <Text style={styles.label}>Full name</Text>
+            <TextInput
+              value={fullName}
+              onChangeText={setFullName}
+              placeholder="Alex Morgan"
+              style={styles.input}
+              textContentType="name"
+            />
+          </View>
+
+          <View style={styles.fieldGroup}>
+            <Text style={styles.label}>Email</Text>
+            <TextInput
+              value={email}
+              onChangeText={setEmail}
+              autoCapitalize="none"
+              keyboardType="email-address"
+              placeholder="you@example.com"
+              style={styles.input}
+              textContentType="emailAddress"
+            />
+          </View>
+
+          <View style={styles.fieldGroup}>
+            <Text style={styles.label}>Password</Text>
+            <TextInput
+              value={password}
+              onChangeText={setPassword}
+              secureTextEntry
+              placeholder="Create a secure password"
+              style={styles.input}
+              textContentType="newPassword"
+            />
+          </View>
+
+          <View style={styles.fieldGroup}>
+            <Text style={styles.label}>Confirm password</Text>
+            <TextInput
+              value={confirmPassword}
+              onChangeText={setConfirmPassword}
+              secureTextEntry
+              placeholder="Re-enter your password"
+              style={styles.input}
+            />
+          </View>
+
+          <View style={styles.toggleRow}>
+            <View style={styles.toggleTextWrapper}>
+              <Text style={styles.toggleLabel}>Marketing updates</Text>
+              <Text style={styles.toggleDescription}>
+                Receive tournament announcements and exclusive partner offers.
+              </Text>
+            </View>
+            <Switch value={marketingOptIn} onValueChange={setMarketingOptIn} />
+          </View>
+
+          <TouchableOpacity
+            style={[styles.primaryButton, (loading || submitting) && styles.primaryButtonDisabled]}
+            onPress={handleSubmit}
+            disabled={loading || submitting}
+          >
+            <Text style={styles.primaryButtonText}>
+              {loading || submitting ? 'Creating account…' : 'Create account'}
+            </Text>
+          </TouchableOpacity>
+
+          <TouchableOpacity onPress={() => navigation.navigate('Login')} style={styles.secondaryAction}>
+            <Text style={styles.secondaryText}>Already have an account? Sign in</Text>
+          </TouchableOpacity>
+        </ScrollView>
+      </KeyboardAvoidingView>
+    </SafeAreaView>
+  );
+};
+
+const styles = StyleSheet.create({
+  flex: {
+    flex: 1,
+  },
+  safeArea: {
+    flex: 1,
+    backgroundColor: '#f9fafb',
+  },
+  content: {
+    flexGrow: 1,
+    padding: 24,
+  },
+  title: {
+    fontSize: 28,
+    fontWeight: '700',
+    color: '#0f172a',
+    marginBottom: 8,
+    textAlign: 'center',
+  },
+  subtitle: {
+    fontSize: 16,
+    color: '#475569',
+    marginBottom: 24,
+    textAlign: 'center',
+  },
+  fieldGroup: {
+    marginBottom: 16,
+  },
+  label: {
+    color: '#1f2937',
+    marginBottom: 8,
+    fontWeight: '600',
+  },
+  input: {
+    backgroundColor: '#fff',
+    borderRadius: 8,
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    borderWidth: 1,
+    borderColor: '#cbd5f5',
+    color: '#0f172a',
+  },
+  toggleRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+    backgroundColor: '#e2e8f0',
+    borderRadius: 12,
+    marginTop: 8,
+    marginBottom: 16,
+  },
+  toggleTextWrapper: {
+    flex: 1,
+    paddingRight: 12,
+  },
+  toggleLabel: {
+    fontWeight: '700',
+    color: '#0f172a',
+    marginBottom: 4,
+  },
+  toggleDescription: {
+    color: '#475569',
+    fontSize: 13,
+    lineHeight: 18,
+  },
+  primaryButton: {
+    backgroundColor: '#2563eb',
+    borderRadius: 8,
+    paddingVertical: 14,
+    alignItems: 'center',
+    marginTop: 8,
+  },
+  primaryButtonDisabled: {
+    opacity: 0.7,
+  },
+  primaryButtonText: {
+    color: '#f8fafc',
+    fontWeight: '700',
+    fontSize: 16,
+  },
+  secondaryAction: {
+    marginTop: 16,
+    alignItems: 'center',
+  },
+  secondaryText: {
+    color: '#2563eb',
+    fontSize: 15,
+  },
+});
+
+export default RegisterScreen;

--- a/football-app/src/services/adminStorage.ts
+++ b/football-app/src/services/adminStorage.ts
@@ -1,0 +1,23 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+import type { AdminSnapshot } from '../types/admin';
+
+const ADMIN_KEY = '@footballapp/adminSnapshot';
+
+export const loadAdminSnapshot = async (): Promise<AdminSnapshot | null> => {
+  const raw = await AsyncStorage.getItem(ADMIN_KEY);
+  if (!raw) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(raw) as AdminSnapshot;
+  } catch (error) {
+    console.warn('Failed to parse admin snapshot', error);
+    return null;
+  }
+};
+
+export const persistAdminSnapshot = async (snapshot: AdminSnapshot): Promise<void> => {
+  await AsyncStorage.setItem(ADMIN_KEY, JSON.stringify(snapshot));
+};

--- a/football-app/src/services/userStorage.ts
+++ b/football-app/src/services/userStorage.ts
@@ -1,0 +1,42 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+import type { StoredUserAccount } from '../types/user';
+
+const USERS_KEY = '@footballapp/users';
+const CURRENT_USER_KEY = '@footballapp/currentUserId';
+
+export const loadStoredUsers = async (): Promise<StoredUserAccount[] | null> => {
+  const raw = await AsyncStorage.getItem(USERS_KEY);
+  if (!raw) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) {
+      return null;
+    }
+
+    return parsed as StoredUserAccount[];
+  } catch (error) {
+    console.warn('Failed to parse stored users', error);
+    return null;
+  }
+};
+
+export const persistUsers = async (users: StoredUserAccount[]): Promise<void> => {
+  await AsyncStorage.setItem(USERS_KEY, JSON.stringify(users));
+};
+
+export const loadStoredCurrentUserId = async (): Promise<string | null> => {
+  const raw = await AsyncStorage.getItem(CURRENT_USER_KEY);
+  return raw ?? null;
+};
+
+export const persistCurrentUserId = async (userId: string | null): Promise<void> => {
+  if (userId) {
+    await AsyncStorage.setItem(CURRENT_USER_KEY, userId);
+  } else {
+    await AsyncStorage.removeItem(CURRENT_USER_KEY);
+  }
+};

--- a/football-app/src/store/index.ts
+++ b/football-app/src/store/index.ts
@@ -4,6 +4,8 @@ import teamsReducer from './slices/teamsSlice';
 import walletReducer from './slices/walletSlice';
 import premiumReducer from './slices/premiumSlice';
 import profileReducer from './slices/profileSlice';
+import { authReducer } from './slices/authSlice';
+import { adminReducer } from './slices/adminSlice';
 
 export const store = configureStore({
   reducer: {
@@ -11,6 +13,8 @@ export const store = configureStore({
     wallet: walletReducer,
     premium: premiumReducer,
     profile: profileReducer,
+    auth: authReducer,
+    admin: adminReducer,
 
   },
 });

--- a/football-app/src/store/slices/adminSlice.ts
+++ b/football-app/src/store/slices/adminSlice.ts
@@ -1,0 +1,275 @@
+import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
+
+import type { RootState } from '..';
+import type {
+  AdminSnapshot,
+  CampaignStatus,
+  MarketingCampaign,
+  MarketingAudience,
+  PaymentRecord,
+  PaymentStatus,
+} from '../../types/admin';
+import { loadAdminSnapshot, persistAdminSnapshot } from '../../services/adminStorage';
+
+interface AdminState extends AdminSnapshot {
+  initialized: boolean;
+  loading: boolean;
+  error: string | null;
+}
+
+const createId = (prefix: string) => `${prefix}_${Math.random().toString(36).slice(2, 10)}`;
+
+const defaultSnapshot = (): AdminSnapshot => ({
+  payments: [
+    {
+      id: 'payment-1',
+      userId: 'fan-jane',
+      userEmail: 'jane@supporters.club',
+      amount: 29.99,
+      currency: 'USD',
+      status: 'completed',
+      recordedAt: new Date('2024-03-12T12:30:00Z').toISOString(),
+      notes: 'Tournament entry fee',
+    },
+    {
+      id: 'payment-2',
+      userId: 'admin-owner',
+      userEmail: 'owner@clubhouse.app',
+      amount: 199,
+      currency: 'USD',
+      status: 'pending',
+      recordedAt: new Date('2024-04-05T09:15:00Z').toISOString(),
+      notes: 'Sponsorship package invoice',
+    },
+  ],
+  marketingCampaigns: [
+    {
+      id: 'campaign-1',
+      title: 'Spring Tournament Kick-off',
+      audience: 'all',
+      status: 'sent',
+      createdAt: new Date('2024-02-28T08:00:00Z').toISOString(),
+      sentAt: new Date('2024-03-01T08:30:00Z').toISOString(),
+      notes: 'Email + push notification campaign',
+    },
+    {
+      id: 'campaign-2',
+      title: 'Premium Coaching Insights',
+      audience: 'premium',
+      status: 'scheduled',
+      createdAt: new Date('2024-05-10T11:00:00Z').toISOString(),
+      scheduledFor: '2024-05-20',
+      notes: 'Exclusive content drip for premium users',
+    },
+  ],
+});
+
+const initialState: AdminState = {
+  ...defaultSnapshot(),
+  initialized: false,
+  loading: false,
+  error: null,
+};
+
+const persistSnapshot = async (snapshot: AdminSnapshot) => {
+  await persistAdminSnapshot(snapshot);
+};
+
+export const initializeAdmin = createAsyncThunk(
+  'admin/initialize',
+  async (_, { rejectWithValue }) => {
+    try {
+      const stored = await loadAdminSnapshot();
+      if (stored) {
+        return stored;
+      }
+
+      const seeded = defaultSnapshot();
+      await persistSnapshot(seeded);
+      return seeded;
+    } catch (error) {
+      console.error('Failed to initialise admin snapshot', error);
+      return rejectWithValue('Unable to load admin centre data');
+    }
+  },
+);
+
+export const updatePaymentStatus = createAsyncThunk<
+  PaymentRecord[],
+  { paymentId: string; status: PaymentStatus },
+  { state: RootState; rejectValue: string }
+>('admin/updatePaymentStatus', async ({ paymentId, status }, { getState, rejectWithValue }) => {
+  const { admin } = getState();
+  const target = admin.payments.find((payment) => payment.id === paymentId);
+
+  if (!target) {
+    return rejectWithValue('Payment not found');
+  }
+
+  const updatedPayments = admin.payments.map((payment) =>
+    payment.id === paymentId
+      ? {
+          ...payment,
+          status,
+        }
+      : payment,
+  );
+
+  await persistSnapshot({ payments: updatedPayments, marketingCampaigns: admin.marketingCampaigns });
+
+  return updatedPayments;
+});
+
+export const recordManualPayment = createAsyncThunk<
+  PaymentRecord[],
+  { userEmail: string; amount: number; currency: string; status?: PaymentStatus; notes?: string },
+  { state: RootState; rejectValue: string }
+>(
+  'admin/recordManualPayment',
+  async ({ userEmail, amount, currency, status = 'completed', notes }, { getState, rejectWithValue }) => {
+    if (!userEmail.trim()) {
+      return rejectWithValue('Email is required to record a payment');
+    }
+
+    if (!Number.isFinite(amount) || amount <= 0) {
+      return rejectWithValue('Enter a valid payment amount');
+    }
+
+    const normalisedEmail = userEmail.trim().toLowerCase();
+    const { auth, admin } = getState();
+    const matchedUser = auth.users.find(
+      (user) => user.email.trim().toLowerCase() === normalisedEmail,
+    );
+
+    const newPayment: PaymentRecord = {
+      id: createId('payment'),
+      userId: matchedUser ? matchedUser.id : null,
+      userEmail: userEmail.trim(),
+      amount,
+      currency: currency.trim().toUpperCase() || 'USD',
+      status,
+      recordedAt: new Date().toISOString(),
+      notes,
+    };
+
+    const updatedPayments = [newPayment, ...admin.payments];
+    await persistSnapshot({ payments: updatedPayments, marketingCampaigns: admin.marketingCampaigns });
+
+    return updatedPayments;
+  },
+);
+
+export const addMarketingCampaign = createAsyncThunk<
+  MarketingCampaign[],
+  { title: string; audience: MarketingAudience; scheduledFor?: string; notes?: string },
+  { state: RootState; rejectValue: string }
+>('admin/addMarketingCampaign', async (payload, { getState, rejectWithValue }) => {
+  const { title, audience, scheduledFor, notes } = payload;
+  const trimmedTitle = title.trim();
+
+  if (!trimmedTitle) {
+    return rejectWithValue('Campaign title is required');
+  }
+
+  const { admin } = getState();
+  const nextStatus: CampaignStatus = scheduledFor?.trim() ? 'scheduled' : 'draft';
+
+  const campaign: MarketingCampaign = {
+    id: createId('campaign'),
+    title: trimmedTitle,
+    audience,
+    status: nextStatus,
+    createdAt: new Date().toISOString(),
+    scheduledFor: scheduledFor?.trim() || undefined,
+    notes: notes?.trim() || undefined,
+  };
+
+  const updatedCampaigns = [campaign, ...admin.marketingCampaigns];
+  await persistSnapshot({ payments: admin.payments, marketingCampaigns: updatedCampaigns });
+
+  return updatedCampaigns;
+});
+
+export const markCampaignAsSent = createAsyncThunk<
+  MarketingCampaign[],
+  { campaignId: string },
+  { state: RootState; rejectValue: string }
+>('admin/markCampaignAsSent', async ({ campaignId }, { getState, rejectWithValue }) => {
+  const { admin } = getState();
+  const target = admin.marketingCampaigns.find((campaign) => campaign.id === campaignId);
+
+  if (!target) {
+    return rejectWithValue('Campaign not found');
+  }
+
+  const updatedCampaigns = admin.marketingCampaigns.map((campaign) =>
+    campaign.id === campaignId
+      ? {
+          ...campaign,
+          status: 'sent',
+          sentAt: new Date().toISOString(),
+        }
+      : campaign,
+  );
+
+  await persistSnapshot({ payments: admin.payments, marketingCampaigns: updatedCampaigns });
+
+  return updatedCampaigns;
+});
+
+const adminSlice = createSlice({
+  name: 'admin',
+  initialState,
+  reducers: {},
+  extraReducers: (builder) => {
+    builder
+      .addCase(initializeAdmin.pending, (state) => {
+        state.loading = true;
+        state.error = null;
+      })
+      .addCase(initializeAdmin.fulfilled, (state, action) => {
+        state.payments = action.payload.payments;
+        state.marketingCampaigns = action.payload.marketingCampaigns;
+        state.initialized = true;
+        state.loading = false;
+      })
+      .addCase(initializeAdmin.rejected, (state, action) => {
+        state.loading = false;
+        state.initialized = true;
+        state.error = (action.payload as string) ?? action.error.message ?? null;
+      })
+      .addCase(updatePaymentStatus.fulfilled, (state, action) => {
+        state.payments = action.payload;
+      })
+      .addCase(updatePaymentStatus.rejected, (state, action) => {
+        state.error = (action.payload as string) ?? action.error.message ?? null;
+      })
+      .addCase(recordManualPayment.fulfilled, (state, action) => {
+        state.payments = action.payload;
+      })
+      .addCase(recordManualPayment.rejected, (state, action) => {
+        state.error = (action.payload as string) ?? action.error.message ?? null;
+      })
+      .addCase(addMarketingCampaign.fulfilled, (state, action) => {
+        state.marketingCampaigns = action.payload;
+      })
+      .addCase(addMarketingCampaign.rejected, (state, action) => {
+        state.error = (action.payload as string) ?? action.error.message ?? null;
+      })
+      .addCase(markCampaignAsSent.fulfilled, (state, action) => {
+        state.marketingCampaigns = action.payload;
+      })
+      .addCase(markCampaignAsSent.rejected, (state, action) => {
+        state.error = (action.payload as string) ?? action.error.message ?? null;
+      });
+  },
+});
+
+export const adminReducer = adminSlice.reducer;
+
+export const selectAdminLoading = (state: RootState) => state.admin.loading;
+export const selectAdminError = (state: RootState) => state.admin.error;
+export const selectAdminInitialized = (state: RootState) => state.admin.initialized;
+export const selectPayments = (state: RootState) => state.admin.payments;
+export const selectMarketingCampaigns = (state: RootState) => state.admin.marketingCampaigns;
+

--- a/football-app/src/store/slices/authSlice.ts
+++ b/football-app/src/store/slices/authSlice.ts
@@ -1,0 +1,322 @@
+import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
+
+import type { RootState } from '..';
+import type { StoredUserAccount, UserAccount, UserStatus } from '../../types/user';
+import { loadStoredUsers, persistCurrentUserId, persistUsers, loadStoredCurrentUserId } from '../../services/userStorage';
+
+interface AuthState {
+  users: StoredUserAccount[];
+  currentUserId: string | null;
+  initialized: boolean;
+  loading: boolean;
+  error: string | null;
+}
+
+const createId = (prefix: string) => `${prefix}_${Math.random().toString(36).slice(2, 10)}`;
+
+const seedUsers = (): StoredUserAccount[] => [
+  {
+    id: 'admin-owner',
+    fullName: 'Club Owner',
+    email: 'owner@clubhouse.app',
+    password: 'admin123',
+    role: 'admin',
+    marketingOptIn: false,
+    status: 'active',
+    createdAt: new Date('2023-01-15T09:00:00Z').toISOString(),
+  },
+  {
+    id: 'fan-jane',
+    fullName: 'Jane Fletcher',
+    email: 'jane@supporters.club',
+    password: 'football',
+    role: 'user',
+    marketingOptIn: true,
+    status: 'active',
+    createdAt: new Date('2023-02-02T13:30:00Z').toISOString(),
+  },
+];
+
+const sanitizeUser = (user: StoredUserAccount): UserAccount => {
+  const { password, ...rest } = user;
+  return rest;
+};
+
+const initialState: AuthState = {
+  users: [],
+  currentUserId: null,
+  initialized: false,
+  loading: false,
+  error: null,
+};
+
+export const initializeAuth = createAsyncThunk(
+  'auth/initialize',
+  async (_, { rejectWithValue }) => {
+    try {
+      const storedUsers = await loadStoredUsers();
+      let users = storedUsers ?? [];
+
+      if (!users.length) {
+        users = seedUsers();
+        await persistUsers(users);
+      }
+
+      const storedCurrentUserId = await loadStoredCurrentUserId();
+      const currentUserId = users.some((user) => user.id === storedCurrentUserId)
+        ? storedCurrentUserId
+        : null;
+
+      if (!currentUserId && storedCurrentUserId) {
+        await persistCurrentUserId(null);
+      }
+
+      return { users, currentUserId };
+    } catch (error) {
+      console.error('Failed to initialize auth state', error);
+      return rejectWithValue('Unable to initialise authentication state');
+    }
+  },
+);
+
+export const registerUser = createAsyncThunk<
+  StoredUserAccount,
+  { fullName: string; email: string; password: string; marketingOptIn: boolean },
+  { state: RootState; rejectValue: string }
+>('auth/registerUser', async (payload, { getState, rejectWithValue }) => {
+  const { fullName, email, password, marketingOptIn } = payload;
+  const normalisedEmail = email.trim().toLowerCase();
+
+  if (!normalisedEmail) {
+    return rejectWithValue('Email is required');
+  }
+
+  const trimmedName = fullName.trim();
+  if (!trimmedName) {
+    return rejectWithValue('Full name is required');
+  }
+
+  if (!password.trim()) {
+    return rejectWithValue('Password is required');
+  }
+
+  const { auth } = getState();
+
+  if (
+    auth.users.some((user) => user.email.trim().toLowerCase() === normalisedEmail)
+  ) {
+    return rejectWithValue('An account with this email already exists');
+  }
+
+  const newUser: StoredUserAccount = {
+    id: createId('user'),
+    fullName: trimmedName,
+    email: normalisedEmail,
+    password: password.trim(),
+    role: 'user',
+    marketingOptIn,
+    status: 'active',
+    createdAt: new Date().toISOString(),
+  };
+
+  const updatedUsers = [...auth.users, newUser];
+  await persistUsers(updatedUsers);
+  await persistCurrentUserId(newUser.id);
+
+  return newUser;
+});
+
+export const loginUser = createAsyncThunk<
+  StoredUserAccount,
+  { email: string; password: string },
+  { state: RootState; rejectValue: string }
+>('auth/loginUser', async ({ email, password }, { getState, rejectWithValue }) => {
+  const normalisedEmail = email.trim().toLowerCase();
+  const providedPassword = password.trim();
+
+  if (!normalisedEmail || !providedPassword) {
+    return rejectWithValue('Email and password are required');
+  }
+
+  const { auth } = getState();
+  const matchedUser = auth.users.find(
+    (user) => user.email.trim().toLowerCase() === normalisedEmail,
+  );
+
+  if (!matchedUser) {
+    return rejectWithValue('No account found with that email');
+  }
+
+  if (matchedUser.password !== providedPassword) {
+    return rejectWithValue('Incorrect password');
+  }
+
+  if (matchedUser.status === 'suspended') {
+    return rejectWithValue('This account has been suspended');
+  }
+
+  await persistCurrentUserId(matchedUser.id);
+  return matchedUser;
+});
+
+export const logoutUser = createAsyncThunk('auth/logoutUser', async () => {
+  await persistCurrentUserId(null);
+});
+
+export const toggleUserStatus = createAsyncThunk<
+  { userId: string; status: UserStatus },
+  { userId: string },
+  { state: RootState; rejectValue: string }
+>('auth/toggleUserStatus', async ({ userId }, { getState, rejectWithValue }) => {
+  const { auth } = getState();
+  const targetUser = auth.users.find((user) => user.id === userId);
+
+  if (!targetUser) {
+    return rejectWithValue('User not found');
+  }
+
+  if (targetUser.role === 'admin') {
+    return rejectWithValue('Admin accounts cannot be suspended');
+  }
+
+  const nextStatus: UserStatus = targetUser.status === 'active' ? 'suspended' : 'active';
+  const updatedUsers = auth.users.map((user) =>
+    user.id === userId
+      ? {
+          ...user,
+          status: nextStatus,
+        }
+      : user,
+  );
+
+  await persistUsers(updatedUsers);
+
+  if (auth.currentUserId === userId && nextStatus === 'suspended') {
+    await persistCurrentUserId(null);
+  }
+
+  return { userId, status: nextStatus };
+});
+
+export const updateMarketingPreference = createAsyncThunk<
+  { userId: string; marketingOptIn: boolean },
+  { userId: string; marketingOptIn: boolean },
+  { state: RootState; rejectValue: string }
+>(
+  'auth/updateMarketingPreference',
+  async ({ userId, marketingOptIn }, { getState, rejectWithValue }) => {
+    const { auth } = getState();
+    const targetUser = auth.users.find((user) => user.id === userId);
+
+    if (!targetUser) {
+      return rejectWithValue('User not found');
+    }
+
+    const updatedUsers = auth.users.map((user) =>
+      user.id === userId
+        ? {
+            ...user,
+            marketingOptIn,
+          }
+        : user,
+    );
+
+    await persistUsers(updatedUsers);
+    return { userId, marketingOptIn };
+  },
+);
+
+const authSlice = createSlice({
+  name: 'auth',
+  initialState,
+  reducers: {},
+  extraReducers: (builder) => {
+    builder
+      .addCase(initializeAuth.pending, (state) => {
+        state.loading = true;
+        state.error = null;
+      })
+      .addCase(initializeAuth.fulfilled, (state, action) => {
+        state.users = action.payload.users;
+        state.currentUserId = action.payload.currentUserId;
+        state.initialized = true;
+        state.loading = false;
+      })
+      .addCase(initializeAuth.rejected, (state, action) => {
+        state.loading = false;
+        state.initialized = true;
+        state.error = (action.payload as string) ?? action.error.message ?? null;
+      })
+      .addCase(registerUser.pending, (state) => {
+        state.loading = true;
+        state.error = null;
+      })
+      .addCase(registerUser.fulfilled, (state, action) => {
+        state.users.push(action.payload);
+        state.currentUserId = action.payload.id;
+        state.loading = false;
+      })
+      .addCase(registerUser.rejected, (state, action) => {
+        state.loading = false;
+        state.error = (action.payload as string) ?? action.error.message ?? null;
+      })
+      .addCase(loginUser.pending, (state) => {
+        state.loading = true;
+        state.error = null;
+      })
+      .addCase(loginUser.fulfilled, (state, action) => {
+        const existingIndex = state.users.findIndex((user) => user.id === action.payload.id);
+        if (existingIndex !== -1) {
+          state.users[existingIndex] = action.payload;
+        }
+        state.currentUserId = action.payload.id;
+        state.loading = false;
+      })
+      .addCase(loginUser.rejected, (state, action) => {
+        state.loading = false;
+        state.error = (action.payload as string) ?? action.error.message ?? null;
+      })
+      .addCase(logoutUser.fulfilled, (state) => {
+        state.currentUserId = null;
+      })
+      .addCase(toggleUserStatus.fulfilled, (state, action) => {
+        const target = state.users.find((user) => user.id === action.payload.userId);
+        if (target) {
+          target.status = action.payload.status;
+        }
+        if (state.currentUserId === action.payload.userId && action.payload.status === 'suspended') {
+          state.currentUserId = null;
+        }
+      })
+      .addCase(toggleUserStatus.rejected, (state, action) => {
+        state.error = (action.payload as string) ?? action.error.message ?? null;
+      })
+      .addCase(updateMarketingPreference.fulfilled, (state, action) => {
+        const target = state.users.find((user) => user.id === action.payload.userId);
+        if (target) {
+          target.marketingOptIn = action.payload.marketingOptIn;
+        }
+      })
+      .addCase(updateMarketingPreference.rejected, (state, action) => {
+        state.error = (action.payload as string) ?? action.error.message ?? null;
+      });
+  },
+});
+
+export const authReducer = authSlice.reducer;
+
+export const selectAuthLoading = (state: RootState) => state.auth.loading;
+export const selectAuthError = (state: RootState) => state.auth.error;
+
+export const selectUsers = (state: RootState): UserAccount[] =>
+  state.auth.users.map(sanitizeUser);
+
+export const selectCurrentUser = (state: RootState): UserAccount | null => {
+  if (!state.auth.currentUserId) {
+    return null;
+  }
+
+  const match = state.auth.users.find((user) => user.id === state.auth.currentUserId);
+  return match ? sanitizeUser(match) : null;
+};
+

--- a/football-app/src/types/admin.ts
+++ b/football-app/src/types/admin.ts
@@ -1,0 +1,32 @@
+export type PaymentStatus = 'pending' | 'completed' | 'failed';
+
+export interface PaymentRecord {
+  id: string;
+  userId: string | null;
+  userEmail: string;
+  amount: number;
+  currency: string;
+  status: PaymentStatus;
+  recordedAt: string;
+  notes?: string;
+}
+
+export type MarketingAudience = 'all' | 'premium' | 'free';
+
+export type CampaignStatus = 'draft' | 'scheduled' | 'sent';
+
+export interface MarketingCampaign {
+  id: string;
+  title: string;
+  audience: MarketingAudience;
+  status: CampaignStatus;
+  createdAt: string;
+  scheduledFor?: string;
+  notes?: string;
+  sentAt?: string;
+}
+
+export interface AdminSnapshot {
+  payments: PaymentRecord[];
+  marketingCampaigns: MarketingCampaign[];
+}

--- a/football-app/src/types/navigation.ts
+++ b/football-app/src/types/navigation.ts
@@ -1,8 +1,11 @@
 export type RootStackParamList = {
+  Login: undefined;
+  Register: undefined;
   Home: undefined;
   Team: undefined;
   CreateTeam: undefined;
   ManageTeam: { teamId: string };
   Tournaments: undefined;
   Profile: undefined;
+  AdminDashboard: undefined;
 };

--- a/football-app/src/types/user.ts
+++ b/football-app/src/types/user.ts
@@ -1,0 +1,17 @@
+export type UserRole = 'user' | 'admin';
+
+export type UserStatus = 'active' | 'suspended';
+
+export interface UserAccount {
+  id: string;
+  fullName: string;
+  email: string;
+  role: UserRole;
+  marketingOptIn: boolean;
+  status: UserStatus;
+  createdAt: string;
+}
+
+export interface StoredUserAccount extends UserAccount {
+  password: string;
+}


### PR DESCRIPTION
## Summary
- add a Redux authentication slice with AsyncStorage persistence and seed accounts
- introduce login and registration screens and gate the navigator based on auth state
- build an admin dashboard with user, payment, and marketing management backed by stored snapshots
- refresh the profile and home screens with account controls and admin access

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e5a4685600832e8705bc7d558b1d47