### PR TITLE
Add interactive formation editor to Manage Team screen

### DIFF
--- a/football-app/src/components/PitchFormation.tsx
+++ b/football-app/src/components/PitchFormation.tsx
@@ -1,0 +1,201 @@
+import React from 'react';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+
+import { FormationPositionKey, TeamMember } from '../store/slices/teamsSlice';
+
+interface FormationSpot {
+  key: FormationPositionKey;
+  label: string;
+  top: string;
+  left: string;
+}
+
+const formationSpots: FormationSpot[] = [
+  { key: 'GK', label: 'GK', top: '82%', left: '50%' },
+  { key: 'RB', label: 'RB', top: '66%', left: '18%' },
+  { key: 'RCB', label: 'RCB', top: '60%', left: '38%' },
+  { key: 'LCB', label: 'LCB', top: '60%', left: '62%' },
+  { key: 'LB', label: 'LB', top: '66%', left: '82%' },
+  { key: 'CDM', label: 'CDM', top: '46%', left: '50%' },
+  { key: 'RM', label: 'RM', top: '38%', left: '22%' },
+  { key: 'CM', label: 'CM', top: '32%', left: '50%' },
+  { key: 'LM', label: 'LM', top: '38%', left: '78%' },
+  { key: 'RW', label: 'RW', top: '16%', left: '30%' },
+  { key: 'ST', label: 'ST', top: '12%', left: '50%' },
+  { key: 'LW', label: 'LW', top: '16%', left: '70%' },
+];
+
+interface PitchFormationProps {
+  members: TeamMember[];
+  selectedMemberId: string | null;
+  onSpotPress: (positionKey: FormationPositionKey, occupantId: string | null) => void;
+}
+
+const PitchFormation: React.FC<PitchFormationProps> = ({ members, selectedMemberId, onSpotPress }) => {
+  const captainId = React.useMemo(() => members.find((member) => member.isCaptain)?.id ?? null, [members]);
+
+  return (
+    <View style={styles.pitchWrapper}>
+      <View style={styles.pitch}>
+        <View style={styles.centerCircle} />
+        <View style={styles.penaltyBoxTop} />
+        <View style={styles.penaltyBoxBottom} />
+        <View style={styles.sixYardBoxTop} />
+        <View style={styles.sixYardBoxBottom} />
+        <View style={styles.centerLine} />
+        {formationSpots.map((spot) => {
+          const occupant = members.find((member) => member.position === spot.key);
+          const isSelected = occupant?.id === selectedMemberId;
+          const isCaptain = occupant?.id && occupant.id === captainId;
+
+          return (
+            <TouchableOpacity
+              key={spot.key}
+              style={[
+                styles.spot,
+                { top: spot.top, left: spot.left },
+                isSelected && styles.spotSelected,
+                !occupant && styles.spotEmpty,
+              ]}
+              onPress={() => onSpotPress(spot.key, occupant ? occupant.id : null)}
+            >
+              <View style={styles.spotContent}>
+                <Text style={styles.spotLabel} numberOfLines={1}>
+                  {occupant ? occupant.name : spot.label}
+                </Text>
+                {occupant ? (
+                  <Text style={styles.spotRole} numberOfLines={1}>
+                    {occupant.role}
+                  </Text>
+                ) : (
+                  <Text style={styles.spotHint}>Tap to assign</Text>
+                )}
+                {isCaptain ? <Text style={styles.captainTag}>C</Text> : null}
+              </View>
+            </TouchableOpacity>
+          );
+        })}
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  pitchWrapper: {
+    width: '100%',
+    aspectRatio: 3 / 4,
+    borderRadius: 24,
+    overflow: 'hidden',
+    borderWidth: 2,
+    borderColor: '#0f766e',
+  },
+  pitch: {
+    flex: 1,
+    backgroundColor: '#0f5132',
+    position: 'relative',
+    padding: 16,
+  },
+  centerCircle: {
+    position: 'absolute',
+    width: '26%',
+    aspectRatio: 1,
+    borderRadius: 999,
+    borderWidth: 2,
+    borderColor: 'rgba(255,255,255,0.4)',
+    top: '37%',
+    left: '37%',
+  },
+  centerLine: {
+    position: 'absolute',
+    left: '50%',
+    width: 2,
+    height: '100%',
+    backgroundColor: 'rgba(255,255,255,0.3)',
+    transform: [{ translateX: -1 }],
+  },
+  penaltyBoxTop: {
+    position: 'absolute',
+    top: '6%',
+    left: '20%',
+    width: '60%',
+    height: '18%',
+    borderWidth: 2,
+    borderColor: 'rgba(255,255,255,0.35)',
+  },
+  penaltyBoxBottom: {
+    position: 'absolute',
+    bottom: '6%',
+    left: '20%',
+    width: '60%',
+    height: '18%',
+    borderWidth: 2,
+    borderColor: 'rgba(255,255,255,0.35)',
+  },
+  sixYardBoxTop: {
+    position: 'absolute',
+    top: '6%',
+    left: '34%',
+    width: '32%',
+    height: '10%',
+    borderWidth: 2,
+    borderColor: 'rgba(255,255,255,0.35)',
+  },
+  sixYardBoxBottom: {
+    position: 'absolute',
+    bottom: '6%',
+    left: '34%',
+    width: '32%',
+    height: '10%',
+    borderWidth: 2,
+    borderColor: 'rgba(255,255,255,0.35)',
+  },
+  spot: {
+    position: 'absolute',
+    width: 96,
+    alignItems: 'center',
+    paddingVertical: 6,
+    paddingHorizontal: 4,
+    borderRadius: 24,
+    borderWidth: 1,
+    borderColor: 'rgba(255,255,255,0.45)',
+    backgroundColor: 'rgba(13, 148, 136, 0.9)',
+    transform: [{ translateX: -48 }],
+  },
+  spotSelected: {
+    backgroundColor: 'rgba(59, 130, 246, 0.9)',
+    borderColor: '#3b82f6',
+  },
+  spotEmpty: {
+    backgroundColor: 'rgba(15, 118, 110, 0.7)',
+  },
+  spotContent: {
+    alignItems: 'center',
+  },
+  spotLabel: {
+    color: '#fff',
+    fontWeight: '700',
+    fontSize: 12,
+  },
+  spotRole: {
+    color: 'rgba(255,255,255,0.75)',
+    fontSize: 10,
+    marginTop: 2,
+  },
+  spotHint: {
+    color: 'rgba(255,255,255,0.6)',
+    fontSize: 10,
+    marginTop: 2,
+  },
+  captainTag: {
+    marginTop: 4,
+    paddingHorizontal: 6,
+    paddingVertical: 2,
+    borderRadius: 999,
+    backgroundColor: 'rgba(245, 158, 11, 0.9)',
+    color: '#0f172a',
+    fontSize: 10,
+    fontWeight: '700',
+  },
+});
+
+export default PitchFormation;

--- a/football-app/src/screens/CreateTeamScreen.tsx
+++ b/football-app/src/screens/CreateTeamScreen.tsx
@@ -6,7 +6,7 @@ import { useNavigation } from '@react-navigation/native';
 
 import { RootStackParamList } from '../types/navigation';
 import { useAppDispatch } from '../store/hooks';
-import { addTeam, defaultTeamSettings } from '../store/slices/teamsSlice';
+import { TeamMember, TeamRole, addTeam, defaultTeamSettings } from '../store/slices/teamsSlice';
 
 type CreateTeamScreenNavigationProp = NativeStackNavigationProp<RootStackParamList, 'CreateTeam'>;
 
@@ -22,6 +22,22 @@ const CreateTeamScreen: React.FC = () => {
     [membersText],
   );
 
+  const determineRoleForIndex = (index: number): TeamRole => {
+    if (index === 0) {
+      return 'Goalkeeper';
+    }
+
+    if (index <= 4) {
+      return 'Defender';
+    }
+
+    if (index <= 8) {
+      return 'Midfielder';
+    }
+
+    return 'Forward';
+  };
+
   const handleSubmit = () => {
     if (!trimmedName) {
       Alert.alert('Missing team name', 'Please give your team a name before saving.');
@@ -29,7 +45,13 @@ const CreateTeamScreen: React.FC = () => {
     }
 
     const teamName = trimmedName;
-    const teamMembers = members;
+    const teamMembers: TeamMember[] = members.map((memberName, index) => ({
+      id: `${Date.now()}-${index}-${memberName.toLowerCase().replace(/[^a-z0-9]/g, '')}`,
+      name: memberName,
+      role: determineRoleForIndex(index),
+      position: null,
+      isCaptain: index === 0,
+    }));
 
     dispatch(
       addTeam({

--- a/football-app/src/screens/ManageTeamScreen.tsx
+++ b/football-app/src/screens/ManageTeamScreen.tsx
@@ -16,10 +16,47 @@ import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 
 import { RootStackParamList } from '../types/navigation';
 import { useAppDispatch, useAppSelector } from '../store/hooks';
-import { TeamSettings, defaultTeamSettings, updateTeam } from '../store/slices/teamsSlice';
+import {
+  FormationPositionKey,
+  TeamMember,
+  TeamRole,
+  TeamSettings,
+  defaultTeamSettings,
+  updateTeam,
+} from '../store/slices/teamsSlice';
+import PitchFormation from '../components/PitchFormation';
 
 type ManageTeamRouteProp = RouteProp<RootStackParamList, 'ManageTeam'>;
 type ManageTeamNavigationProp = NativeStackNavigationProp<RootStackParamList, 'ManageTeam'>;
+
+const TEAM_ROLES: TeamRole[] = ['Goalkeeper', 'Defender', 'Midfielder', 'Forward', 'Substitute'];
+
+const determineDefaultRole = (index: number): TeamRole => {
+  if (index === 0) {
+    return 'Goalkeeper';
+  }
+
+  if (index <= 4) {
+    return 'Defender';
+  }
+
+  if (index <= 8) {
+    return 'Midfielder';
+  }
+
+  return 'Forward';
+};
+
+const createTeamMemberFromName = (name: string, existingMembers: TeamMember[]): TeamMember => {
+  const index = existingMembers.length;
+  return {
+    id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    name,
+    role: determineDefaultRole(index),
+    position: null,
+    isCaptain: existingMembers.length === 0,
+  };
+};
 
 const ManageTeamScreen: React.FC = () => {
   const route = useRoute<ManageTeamRouteProp>();
@@ -31,16 +68,19 @@ const ManageTeamScreen: React.FC = () => {
   );
 
   const [teamName, setTeamName] = useState('');
-  const [members, setMembers] = useState<string[]>([]);
+  const [members, setMembers] = useState<TeamMember[]>([]);
   const [newMember, setNewMember] = useState('');
   const [settings, setSettings] = useState<TeamSettings>(defaultTeamSettings);
   const [usernameQuery, setUsernameQuery] = useState('');
+  const [selectedMemberId, setSelectedMemberId] = useState<string | null>(null);
 
   useEffect(() => {
     if (team) {
       setTeamName(team.name);
       setMembers(team.members);
       setSettings(team.settings);
+      const captain = team.members.find((member) => member.isCaptain);
+      setSelectedMemberId(captain?.id ?? team.members[0]?.id ?? null);
     }
   }, [team]);
 
@@ -67,17 +107,123 @@ const ManageTeamScreen: React.FC = () => {
       return;
     }
 
-    if (members.some((member) => member.toLowerCase() === trimmedMember.toLowerCase())) {
+    if (members.some((member) => member.name.toLowerCase() === trimmedMember.toLowerCase())) {
       Alert.alert('Already added', `${trimmedMember} is already part of your roster.`);
       return;
     }
 
-    setMembers((previousMembers) => [...previousMembers, trimmedMember]);
+    setMembers((previousMembers) => {
+      const cleanedName = trimmedMember;
+      const newMemberEntry = createTeamMemberFromName(cleanedName, previousMembers);
+
+      const updatedMembers = [...previousMembers.map((member) => ({ ...member })), newMemberEntry];
+
+      setSelectedMemberId(newMemberEntry.id);
+
+      return updatedMembers;
+    });
     setNewMember('');
   };
 
-  const handleRemoveMember = (index: number) => {
-    setMembers((previousMembers) => previousMembers.filter((_, memberIndex) => memberIndex !== index));
+  const handleRemoveMember = (memberId: string) => {
+    setMembers((previousMembers) => {
+      const filteredMembers = previousMembers
+        .filter((member) => member.id !== memberId)
+        .map((member) => ({ ...member }));
+
+      if (filteredMembers.length > 0 && !filteredMembers.some((member) => member.isCaptain)) {
+        filteredMembers.forEach((member, index) => {
+          filteredMembers[index] = { ...member, isCaptain: index === 0 };
+        });
+        setSelectedMemberId((currentSelected) =>
+          currentSelected === memberId ? filteredMembers[0].id : currentSelected,
+        );
+      } else if (filteredMembers.length === 0) {
+        setSelectedMemberId(null);
+      } else if (filteredMembers.some((member) => member.isCaptain)) {
+        const captain = filteredMembers.find((member) => member.isCaptain);
+        setSelectedMemberId((currentSelected) =>
+          currentSelected === memberId ? captain?.id ?? filteredMembers[0].id : currentSelected,
+        );
+      }
+
+      return filteredMembers;
+    });
+  };
+
+  const handleSelectMember = (memberId: string) => {
+    setSelectedMemberId((currentSelected) => (currentSelected === memberId ? null : memberId));
+  };
+
+  const handleCycleRole = (memberId: string) => {
+    setMembers((previousMembers) =>
+      previousMembers.map((member) => {
+        if (member.id !== memberId) {
+          return member;
+        }
+
+        const currentIndex = Math.max(0, TEAM_ROLES.indexOf(member.role));
+        const nextRole = TEAM_ROLES[(currentIndex + 1) % TEAM_ROLES.length];
+
+        return { ...member, role: nextRole };
+      }),
+    );
+  };
+
+  const handleSetCaptain = (memberId: string) => {
+    setMembers((previousMembers) =>
+      previousMembers.map((member) => ({
+        ...member,
+        isCaptain: member.id === memberId,
+      })),
+    );
+    setSelectedMemberId(memberId);
+  };
+
+  const handleClearPosition = (memberId: string) => {
+    setMembers((previousMembers) =>
+      previousMembers.map((member) =>
+        member.id === memberId ? { ...member, position: null } : member,
+      ),
+    );
+  };
+
+  const handleSpotPress = (positionKey: FormationPositionKey, occupantId: string | null) => {
+    if (!selectedMemberId) {
+      if (occupantId) {
+        setMembers((previousMembers) =>
+          previousMembers.map((member) =>
+            member.id === occupantId ? { ...member, position: null } : member,
+          ),
+        );
+      } else {
+        Alert.alert('Select a player', 'Choose a player from the roster before assigning a position.');
+      }
+      return;
+    }
+
+    if (occupantId && occupantId === selectedMemberId) {
+      setMembers((previousMembers) =>
+        previousMembers.map((member) =>
+          member.id === selectedMemberId ? { ...member, position: null } : member,
+        ),
+      );
+      return;
+    }
+
+    setMembers((previousMembers) =>
+      previousMembers.map((member) => {
+        if (member.id === selectedMemberId) {
+          return { ...member, position: positionKey };
+        }
+
+        if (member.position === positionKey) {
+          return { ...member, position: null };
+        }
+
+        return member;
+      }),
+    );
   };
 
   const handleInviteFromContacts = () => {
@@ -156,14 +302,24 @@ const ManageTeamScreen: React.FC = () => {
     }
 
     const cleanedMembers = members
-      .map((member) => member.trim())
-      .filter((member) => member.length > 0);
+      .map((member) => ({
+        ...member,
+        name: member.name.trim(),
+      }))
+      .filter((member) => member.name.length > 0);
+
+    const ensuredCaptainMembers = cleanedMembers.some((member) => member.isCaptain)
+      ? cleanedMembers
+      : cleanedMembers.map((member, index) => ({
+          ...member,
+          isCaptain: index === 0,
+        }));
 
     dispatch(
       updateTeam({
         id: route.params.teamId,
         name: trimmedName,
-        members: cleanedMembers,
+        members: ensuredCaptainMembers,
         settings,
       }),
     );
@@ -205,20 +361,71 @@ const ManageTeamScreen: React.FC = () => {
             {members.length === 0 ? (
               <Text style={styles.emptyState}>No members yet. Start by inviting your first player.</Text>
             ) : (
-              members.map((member, index) => (
-                <View key={`${member}-${index}`} style={styles.memberRow}>
-                  <Text style={styles.memberName}>{member}</Text>
-                  <TouchableOpacity onPress={() => handleRemoveMember(index)}>
-                    <Text style={styles.removeMemberText}>Remove</Text>
-                  </TouchableOpacity>
-                </View>
-              ))
-            )}
-          </View>
+              <View style={styles.memberList}>
+                {members.map((member) => (
+                  <View
+                    key={member.id}
+                    style={[styles.memberCard, selectedMemberId === member.id && styles.memberCardSelected]}
+                  >
+                    <TouchableOpacity
+                      style={styles.memberCardBody}
+                      onPress={() => handleSelectMember(member.id)}
+                    >
+                      <View style={styles.memberHeaderRow}>
+                        <Text style={styles.memberName}>{member.name}</Text>
+                        {member.isCaptain ? <Text style={styles.captainBadge}>Captain</Text> : null}
+                      </View>
+                      <Text style={styles.memberPositionText}>
+                        {member.position ? `Pitch position: ${member.position}` : 'Not placed on the pitch yet'}
+                      </Text>
+                      <Text style={styles.memberSelectHint}>
+                        {selectedMemberId === member.id
+                          ? 'Selected for pitch placement'
+                          : 'Tap to select and place on the pitch'}
+                      </Text>
+                    </TouchableOpacity>
 
-          <View style={styles.addMemberRow}>
-            <TextInput
-              value={newMember}
+                    <View style={styles.memberFooterRow}>
+                      <TouchableOpacity
+                        style={styles.roleButton}
+                        onPress={() => handleCycleRole(member.id)}
+                      >
+                        <Text style={styles.roleButtonText}>{member.role}</Text>
+                        <Text style={styles.roleButtonHint}>Change role</Text>
+                      </TouchableOpacity>
+
+                      <View style={styles.memberActionGroup}>
+                        <TouchableOpacity
+                          style={styles.secondaryAction}
+                          onPress={() => handleClearPosition(member.id)}
+                        >
+                          <Text style={styles.secondaryActionText}>Clear spot</Text>
+                        </TouchableOpacity>
+                        {member.isCaptain ? null : (
+                          <TouchableOpacity
+                            style={styles.secondaryAction}
+                            onPress={() => handleSetCaptain(member.id)}
+                          >
+                            <Text style={styles.secondaryActionText}>Make captain</Text>
+                          </TouchableOpacity>
+                        )}
+                        <TouchableOpacity
+                          style={styles.removeAction}
+                          onPress={() => handleRemoveMember(member.id)}
+                        >
+                          <Text style={styles.removeActionText}>Remove</Text>
+                        </TouchableOpacity>
+                      </View>
+                    </View>
+                  </View>
+                ))}
+              </View>
+            )}
+        </View>
+
+        <View style={styles.addMemberRow}>
+          <TextInput
+            value={newMember}
               onChangeText={setNewMember}
               placeholder="Add member by name or email"
               style={[styles.input, styles.addMemberInput]}
@@ -227,6 +434,23 @@ const ManageTeamScreen: React.FC = () => {
               <Text style={styles.addMemberButtonText}>Add</Text>
             </TouchableOpacity>
           </View>
+        </View>
+
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>Team structure</Text>
+          <Text style={styles.sectionSubtitle}>
+            Select a player from the roster, then tap a marker to place them on the pitch.
+          </Text>
+
+          <PitchFormation
+            members={members}
+            selectedMemberId={selectedMemberId}
+            onSpotPress={handleSpotPress}
+          />
+
+          <Text style={styles.pitchInstructions}>
+            The captain is highlighted with a badge and can be reassigned at any time.
+          </Text>
         </View>
 
         <View style={styles.section}>
@@ -409,22 +633,98 @@ const styles = StyleSheet.create({
     color: '#94a3b8',
     fontStyle: 'italic',
   },
-  memberRow: {
+  memberList: {
+    marginTop: 8,
+  },
+  memberCard: {
+    backgroundColor: '#f8fafc',
+    borderRadius: 16,
+    padding: 16,
+    borderWidth: 1,
+    borderColor: '#e2e8f0',
+    marginBottom: 12,
+  },
+  memberCardSelected: {
+    borderColor: '#2563eb',
+    shadowColor: '#2563eb',
+    shadowOpacity: 0.2,
+    shadowRadius: 8,
+    shadowOffset: { width: 0, height: 4 },
+    elevation: 3,
+  },
+  memberCardBody: {
+    marginBottom: 12,
+  },
+  memberHeaderRow: {
     flexDirection: 'row',
     justifyContent: 'space-between',
     alignItems: 'center',
-    backgroundColor: '#f1f5f9',
-    borderRadius: 12,
-    paddingHorizontal: 14,
-    paddingVertical: 10,
+    marginBottom: 8,
   },
   memberName: {
-    fontWeight: '600',
-    color: '#1f2937',
+    fontWeight: '700',
+    color: '#0f172a',
+    fontSize: 16,
   },
-  removeMemberText: {
-    color: '#ef4444',
+  captainBadge: {
+    backgroundColor: '#facc15',
+    color: '#1e293b',
+    fontWeight: '700',
+    fontSize: 12,
+    paddingHorizontal: 10,
+    paddingVertical: 4,
+    borderRadius: 999,
+  },
+  memberPositionText: {
+    color: '#1f2937',
+    fontSize: 14,
+  },
+  memberSelectHint: {
+    marginTop: 6,
+    color: '#64748b',
+    fontSize: 12,
+  },
+  memberFooterRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    flexWrap: 'wrap',
+  },
+  roleButton: {
+    backgroundColor: '#dbeafe',
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+    borderRadius: 999,
+    alignItems: 'center',
+    marginBottom: 8,
+  },
+  roleButtonText: {
+    fontWeight: '700',
+    color: '#1d4ed8',
+  },
+  roleButtonHint: {
+    fontSize: 11,
+    color: '#1d4ed8',
+  },
+  memberActionGroup: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginTop: 8,
+    marginLeft: 12,
+  },
+  secondaryAction: {
+    marginRight: 12,
+  },
+  secondaryActionText: {
+    color: '#2563eb',
     fontWeight: '600',
+  },
+  removeAction: {
+    marginRight: 0,
+  },
+  removeActionText: {
+    color: '#ef4444',
+    fontWeight: '700',
   },
   addMemberRow: {
     flexDirection: 'row',
@@ -493,6 +793,11 @@ const styles = StyleSheet.create({
   usernameButtonText: {
     color: '#fff',
     fontWeight: '700',
+  },
+  pitchInstructions: {
+    marginTop: 12,
+    color: '#475569',
+    fontSize: 13,
   },
   saveButton: {
     backgroundColor: '#16a34a',


### PR DESCRIPTION
## Summary
- add a reusable pitch formation component to visualise lineup slots on a football pitch
- extend team state to store member roles, captaincy and pitch assignments and surface controls in Manage Team
- update team creation flow to initialise structured members with default roles

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e5a70fd0e0832e8dfc3b292d55362b