### PR TITLE
Add actionable plan for completing publishing checklist

### DIFF
--- a/docs/publishing-action-plan.md
+++ b/docs/publishing-action-plan.md
@@ -1,0 +1,68 @@
+# Publishing Completion Plan
+
+This plan converts the outstanding items from [`publishing-status.md`](./publishing-status.md) into an actionable workflow. Tasks are grouped by phase and sequenced so that prerequisites unblock downstream submission steps for Google Play and the Apple App Store.
+
+## Phase 1 – Account access and legal readiness
+1. **Confirm developer program enrollment**
+   - Verify active ownership of the Google Play Console and Apple Developer Program accounts.
+   - Document billing owners and renewal reminders.
+2. **Finalize legal documents**
+   - Draft or procure the public-facing privacy policy and terms of service.
+   - Validate GDPR/CCPA consent language with legal counsel and outline the in-app consent flow.
+3. **Audit third-party licenses**
+   - Inventory bundled SDKs, libraries, fonts, and media.
+   - Record license obligations and attach proof of compliance in the repository.
+
+## Phase 2 – Marketing assets and store copy
+4. **Author store metadata**
+   - Write the final app name, short description, full description, keywords, and support/marketing URLs.
+   - Store the copy in version control for iterative review.
+5. **Produce visual assets**
+   - Design high-resolution icons, feature graphics, and screenshots for required device breakpoints.
+   - Capture or edit promotional video footage if desired.
+6. **Review localization needs**
+   - Identify target locales and determine whether translations are required for copy or imagery.
+
+## Phase 3 – Build configuration and environment hardening
+7. **Lock production identifiers and signing**
+   - Choose the Android `applicationId` and iOS bundle identifier; update the respective project files.
+   - Generate production signing keys/certificates and document secure storage.
+8. **Prepare environment configuration**
+   - Replace placeholder values in `.env.example` with production-ready variables.
+   - Establish secrets management for CI/CD and local release builds.
+9. **Define permission and privacy disclosures**
+   - Draft justifications for each platform permission.
+   - Prepare the data collection/usage responses needed for privacy labels on both stores.
+
+## Phase 4 – Quality validation
+10. **Expand test coverage**
+    - Augment automated tests for critical flows and add manual regression scenarios.
+    - Schedule performance, accessibility, and offline evaluations with tooling or QA resources.
+11. **Run beta distributions**
+    - Configure Firebase App Distribution (Android) and TestFlight (iOS) with production signing builds.
+    - Collect crash/analytics feedback and resolve issues prior to submission.
+12. **Review policy compliance**
+    - Complete an internal audit against Google Play policies and the App Store Review Guidelines.
+    - Update the app or documentation to address any potential violations.
+
+## Phase 5 – Store submission execution
+13. **Prepare Google Play release**
+    - Create the application record, populate the main store listing, and upload imagery.
+    - Complete the App Content questionnaire, pricing & distribution, and upload the release AAB with notes.
+    - Resolve pre-launch warnings, then submit the production release for review and monitor status.
+14. **Prepare App Store release**
+    - Create the App Store Connect app record with metadata, categories, age rating, and content rights.
+    - Upload required screenshots, previews, and the signed IPA build.
+    - Configure App Privacy responses, attach release notes, submit for review, and handle any feedback.
+
+## Phase 6 – Post-launch operations
+15. **Establish monitoring and feedback loops**
+    - Configure analytics dashboards, crash reporting alerts, and review response processes.
+    - Schedule periodic store listing refreshes and policy compliance reviews.
+16. **Plan release cadence**
+    - Define criteria for hotfixes versus feature releases.
+    - Document a roadmap for post-launch iterations and assign owners.
+
+### Next steps
+- Assign an owner and target date to each task.
+- Track progress by updating the status table whenever a task moves from "Outstanding" to "Completed".

--- a/docs/publishing-guide.md
+++ b/docs/publishing-guide.md
@@ -1,0 +1,55 @@
+# Mobile App Store Publishing Checklist
+
+This checklist summarizes the key steps required to launch the application on both Google Play and the Apple App Store.
+
+## Prerequisites
+- **Developer accounts**
+  - Enroll in the [Google Play Console](https://play.google.com/console) with a one-time registration fee.
+  - Enroll in the [Apple Developer Program](https://developer.apple.com/programs/) and maintain the annual membership.
+- **App assets ready**
+  - Final app name, description, keywords, and privacy policy URL.
+  - High-resolution icon, feature graphics, and screenshots that meet the store guidelines for all targeted devices.
+  - Promotional videos or trailers (optional but recommended).
+- **Legal and compliance checks**
+  - Confirm that third-party content has the necessary licenses.
+  - Provide clear terms of service and privacy policy, especially if collecting user data.
+  - Ensure GDPR/CCPA compliance for handling personal data and include an in-app consent flow if required.
+
+## Technical preparation
+- **Build configuration**
+  - Configure package identifiers (`applicationId` for Android, `Bundle Identifier` for iOS) and versioning (version code/name and build number).
+  - Set up signing keys: upload keystore information to the Play Console and configure signing certificates/profiles in Xcode/App Store Connect.
+  - Verify that environment-specific configuration (API keys, endpoints) is set for production.
+- **Testing**
+  - Run automated test suites and perform manual regression testing on a range of devices.
+  - Validate performance, accessibility, and offline behavior.
+  - Confirm crash-free startup by using beta channels (Firebase App Distribution, TestFlight) before public release.
+- **Store compliance**
+  - Review store guidelines (Google Play Developer Policies and App Store Review Guidelines) to avoid rejection.
+  - Prepare privacy labels (data collection, usage, tracking) for both stores.
+  - Ensure the app includes required permission justifications and in-app disclosures.
+
+## Google Play submission steps
+1. Create a new application entry in the Play Console and complete the **Main store listing** with localized descriptions, screenshots, and promotional assets.
+2. Fill in **App content** sections: target audience, data safety form, ads declaration, and accessibility details.
+3. Configure **Pricing & distribution**: select countries, device categories, and opt in to Google Play programs if desired.
+4. Upload the **Android App Bundle (AAB)** via the *Production* track (or internal/testing tracks first) and provide release notes.
+5. Complete **Pre-launch checks** and resolve any warnings (e.g., policy issues, performance, security) reported by Google.
+6. Submit the release for **review** and monitor the review status until it is approved and published.
+
+## Apple App Store submission steps
+1. Log in to App Store Connect, create a new app record, and enter metadata (name, subtitle, description, keywords, support URL, marketing URL).
+2. Upload required **App Store assets**: screenshots for each device size, app previews, and promotional text.
+3. Provide the **App Privacy** responses and attach the privacy policy URL.
+4. Configure **App Information**: primary/secondary categories, age rating, and content rights declarations.
+5. In Xcode or via Transporter, upload the **Signed IPA build** that matches the app record's bundle identifier and version/build number.
+6. Add the new build to the **App Store version** section, write release notes, and set availability and pricing.
+7. Submit the app for **App Review**, respond to feedback if required, and when approved, release manually or automatically.
+
+## Post-launch maintenance
+- Monitor analytics, crash reports (Firebase Crashlytics, App Store Connect metrics), and user reviews.
+- Prepare quick follow-up releases for critical bug fixes.
+- Keep store listings updated with new features, seasonal events, or localization improvements.
+- Stay informed about policy updates from both stores to maintain compliance.
+
+Following this process will help streamline review and reduce the chance of last-minute blockers during submission.

--- a/docs/publishing-status.md
+++ b/docs/publishing-status.md
@@ -1,0 +1,56 @@
+# Publishing Checklist Status
+
+This document tracks the current completion status of each task in the mobile publishing checklist. Items marked as **Completed** have verifiable evidence in the repository or were executed during this review. Items marked as **Outstanding** still require action or confirmation outside the repository.
+
+## Prerequisites
+| Item | Status | Notes |
+| --- | --- | --- |
+| Google Play Console developer account enrollment | Outstanding | Requires confirmation of account ownership; no repository evidence available. |
+| Apple Developer Program enrollment | Outstanding | Requires confirmation of account ownership; no repository evidence available. |
+| Store-ready app name, description, keywords, privacy policy URL | Outstanding | Store metadata has not been captured in the repository. |
+| High-resolution icons, feature graphics, screenshots | Outstanding | `assets/icons` only contains a placeholder file—store imagery still needs to be produced. |
+| Promotional video or trailer | Outstanding | No media assets or references are tracked in the repository. |
+| Third-party license verification | Outstanding | Legal review must be confirmed separately. |
+| Terms of service and privacy policy | Outstanding | No documents or links exist in the repo. |
+| GDPR/CCPA consent flow | Outstanding | No implementation or documentation confirming compliance is present. |
+
+## Technical preparation
+| Item | Status | Notes |
+| --- | --- | --- |
+| Configure package identifiers, versioning, and signing | Outstanding | Android `build.gradle` only defines ad ID placeholders and lacks production identifiers or signing; the iOS `Info.plist` omits a bundle identifier. |
+| Production environment configuration | Outstanding | `.env.example` still contains placeholder values. |
+| Automated and manual regression testing | Completed | `npm test` passes using the existing assertion suite. |
+| Performance, accessibility, and offline validation | Outstanding | No reports or tooling results are stored in the repo. |
+| Crash-free beta testing (Firebase App Distribution/TestFlight) | Outstanding | No beta channel artifacts or notes are available. |
+| Review Google Play/App Store policy guidelines | Outstanding | No evidence of policy review is tracked. |
+| Prepare privacy labels and data disclosures | Outstanding | Required privacy responses are not documented. |
+| Permission justifications and in-app disclosures | Outstanding | No documentation or in-app copy confirming this work. |
+
+## Google Play submission steps
+| Step | Status | Notes |
+| --- | --- | --- |
+| Create application entry and main store listing | Outstanding | No Play Console metadata exported. |
+| Complete App Content section (target audience, data safety, ads) | Outstanding | No evidence available. |
+| Configure pricing & distribution | Outstanding | Distribution settings not recorded. |
+| Upload production AAB and release notes | Outstanding | Release artifacts are absent. |
+| Resolve pre-launch check warnings | Outstanding | No pre-launch reports captured. |
+| Submit for review and monitor approval | Outstanding | Submission has not been initiated. |
+
+## Apple App Store submission steps
+| Step | Status | Notes |
+| --- | --- | --- |
+| Create App Store Connect record with metadata | Outstanding | No App Store Connect metadata stored. |
+| Upload device screenshots and previews | Outstanding | Media assets are missing. |
+| Provide App Privacy responses and policy URL | Outstanding | Privacy disclosures not documented. |
+| Configure categories, age rating, content rights | Outstanding | Settings not recorded. |
+| Upload signed IPA build via Xcode/Transporter | Outstanding | No build artifacts tracked. |
+| Attach build to App Store version and add release notes | Outstanding | Not yet prepared. |
+| Submit for App Review and respond to feedback | Outstanding | Submission has not occurred. |
+
+## Post-launch maintenance
+| Item | Status | Notes |
+| --- | --- | --- |
+| Monitor analytics, crash reports, and reviews | Outstanding | Monitoring plan and tooling configuration not documented. |
+| Schedule follow-up bug fix releases | Outstanding | Release management plan not defined. |
+| Keep store listings updated | Outstanding | No process or content updates are logged. |
+| Track policy changes and maintain compliance | Outstanding | No ongoing compliance log is maintained. |


### PR DESCRIPTION
## Summary
- translate the outstanding items in `publishing-status.md` into a sequenced action plan
- outline six phases covering accounts, assets, configuration, validation, submission, and post-launch work
- highlight immediate next steps for assigning owners and due dates

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68e5aa59d698832ead6801336cb56ef3