### PR TITLE
Implement scheduling, scouting, and engagement modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # footballapp
-football app to encourage people around to create a team and play football
+
+Football app to encourage people around to create a team and play football.
+
+## Documentation
+- [Additional Feature Ideas](docs/additional-feature-ideas.md)

--- a/docs/additional-feature-ideas.md
+++ b/docs/additional-feature-ideas.md
@@ -1,0 +1,28 @@
+# Additional Feature Ideas
+
+This document captures high-level feature concepts that can guide future development for the football app. Each idea builds upon existing modules to broaden user engagement and monetize premium experiences.
+
+## Match Scheduling Module
+- Allow team captains to propose friendly or competitive fixtures with preferred venues and tentative kickoff windows.
+- Enable teammates to vote on proposed kickoff times directly in-app, surfacing the final selection in the team calendar.
+- Offer one-tap syncing of accepted matches to device calendars and tie confirmed fixtures to win/loss records on the Team screen.
+
+## Scouting Marketplace
+- Provide a marketplace where teams can publish open roster spots, skill requirements, and availability expectations.
+- Surface free-agent profiles with existing bio data, stats, and social handles to help captains evaluate talent.
+- Support invitations and trial requests so teams can quickly connect with prospective players.
+
+## Seasonal Ladder Tournaments
+- Extend tournaments into seasonal ladders with multiple promotion and relegation tiers for ongoing competition.
+- Use wallet credits as entry stakes and as rewards for promotion, encouraging continued participation.
+- Unlock advanced analytics, matchup history, and performance insights for premium subscribers already teased in the Tournament view.
+
+## Community Challenges
+- Introduce weekly skill drills or fitness challenges on the Home screen to spark engagement before users manage teams or tournaments.
+- Reward successful participation with credits, cosmetic badges, or leaderboard recognition to cultivate friendly competition.
+- Highlight top performers and allow sharing accomplishments through existing social integrations.
+
+## Localized Training and Wellness Tips
+- Deliver training plans, nutrition advice, or recovery tips tailored to each user’s stored demographics and preferences.
+- Offer premium-gated content tiers that provide deeper guidance, video walkthroughs, or personalized coaching plans.
+- Use push notifications or in-app reminders to keep players on track with their selected regimens.

--- a/football-app/src/components/TeamCard.tsx
+++ b/football-app/src/components/TeamCard.tsx
@@ -3,18 +3,50 @@ import { StyleSheet, Text, View, TouchableOpacity } from 'react-native';
 
 import type { Team } from '../store/slices/teamsSlice';
 
+interface TeamRecordSummary {
+  wins: number;
+  draws: number;
+  losses: number;
+}
+
 interface TeamCardProps {
   team: Team;
   onRemove: () => void;
   onManage: () => void;
+  record?: TeamRecordSummary;
+  nextFixtureLabel?: string;
 }
 
 
-const TeamCard: React.FC<TeamCardProps> = ({ team, onRemove, onManage }) => {
+const TeamCard: React.FC<TeamCardProps> = ({
+  team,
+  onRemove,
+  onManage,
+  record,
+  nextFixtureLabel,
+}) => {
+  const hasRecord = record && (record.wins > 0 || record.draws > 0 || record.losses > 0);
+
   return (
     <View style={styles.card}>
       <Text style={styles.name}>{team.name}</Text>
       <Text style={styles.memberCount}>{team.members.length} members</Text>
+
+      {hasRecord ? (
+        <View style={styles.recordRow}>
+          <Text style={styles.recordLabel}>Record</Text>
+          <Text style={styles.recordValue}>
+            {record?.wins ?? 0}-{record?.draws ?? 0}-{record?.losses ?? 0}
+          </Text>
+        </View>
+      ) : null}
+
+      {nextFixtureLabel ? (
+        <View style={styles.fixtureRow}>
+          <Text style={styles.fixtureLabel}>Next kickoff</Text>
+          <Text style={styles.fixtureValue}>{nextFixtureLabel}</Text>
+        </View>
+      ) : null}
 
       <View style={styles.actions}>
         <TouchableOpacity onPress={onManage} style={[styles.button, styles.manageButton]}>
@@ -48,6 +80,39 @@ const styles = StyleSheet.create({
   memberCount: {
     color: '#6b7280',
     marginBottom: 12,
+  },
+  recordRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingVertical: 4,
+  },
+  recordLabel: {
+    fontSize: 12,
+    color: '#475569',
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+  },
+  recordValue: {
+    fontWeight: '700',
+    color: '#0f172a',
+  },
+  fixtureRow: {
+    marginTop: 4,
+    backgroundColor: '#eff6ff',
+    borderRadius: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+  },
+  fixtureLabel: {
+    fontSize: 12,
+    color: '#1d4ed8',
+    marginBottom: 2,
+    fontWeight: '600',
+  },
+  fixtureValue: {
+    fontSize: 14,
+    color: '#1e293b',
   },
   actions: {
     flexDirection: 'row',

--- a/football-app/src/screens/ManageTeamScreen.tsx
+++ b/football-app/src/screens/ManageTeamScreen.tsx
@@ -26,6 +26,23 @@ import {
   updateTeam,
 } from '../store/slices/teamsSlice';
 import PitchFormation from '../components/PitchFormation';
+import {
+  acceptFixtureKickoff,
+  formatKickoffTime,
+  getFixtureStartDate,
+  proposeFixture,
+  recordFixtureResult,
+  selectFixturesByTeam,
+  syncFixtureToCalendar,
+  voteOnKickoff,
+} from '../store/slices/scheduleSlice';
+import {
+  createOpenPosition,
+  inviteFreeAgent,
+  selectFreeAgents,
+  selectOpenPositionsForTeam,
+  updateOpenPositionStatus,
+} from '../store/slices/scoutingSlice';
 
 type ManageTeamRouteProp = RouteProp<RootStackParamList, 'ManageTeam'>;
 type ManageTeamNavigationProp = NativeStackNavigationProp<RootStackParamList, 'ManageTeam'>;
@@ -67,6 +84,11 @@ const ManageTeamScreen: React.FC = () => {
   const team = useAppSelector((state) =>
     state.teams.teams.find((currentTeam) => currentTeam.id === route.params.teamId),
   );
+  const fixtures = useAppSelector((state) => selectFixturesByTeam(state, route.params.teamId));
+  const openPositions = useAppSelector((state) =>
+    selectOpenPositionsForTeam(state, route.params.teamId),
+  );
+  const marketplaceFreeAgents = useAppSelector(selectFreeAgents);
 
   const [teamName, setTeamName] = useState('');
   const [members, setMembers] = useState<TeamMember[]>([]);
@@ -74,6 +96,16 @@ const ManageTeamScreen: React.FC = () => {
   const [settings, setSettings] = useState<TeamSettings>(defaultTeamSettings);
   const [usernameQuery, setUsernameQuery] = useState('');
   const [selectedMemberId, setSelectedMemberId] = useState<string | null>(null);
+  const [fixtureOpponent, setFixtureOpponent] = useState('');
+  const [fixtureLocation, setFixtureLocation] = useState('');
+  const [fixtureOptionOne, setFixtureOptionOne] = useState('');
+  const [fixtureOptionTwo, setFixtureOptionTwo] = useState('');
+  const [fixtureNotes, setFixtureNotes] = useState('');
+  const [positionTitle, setPositionTitle] = useState('');
+  const [positionCommitment, setPositionCommitment] = useState<'casual' | 'competitive'>(
+    'competitive',
+  );
+  const [positionDescription, setPositionDescription] = useState('');
 
   useEffect(() => {
     if (team) {
@@ -92,6 +124,18 @@ const ManageTeamScreen: React.FC = () => {
 
     return `Join ${displayName} on Football App! Use the link ${invitationLink} to connect and see upcoming matches.`;
   }, [invitationLink, teamName]);
+
+  const sortedFixtures = useMemo(() => {
+    return fixtures
+      .slice()
+      .sort((a, b) => {
+        const aDate = getFixtureStartDate(a);
+        const bDate = getFixtureStartDate(b);
+        const aTime = aDate ? aDate.getTime() : Number.MAX_SAFE_INTEGER;
+        const bTime = bDate ? bDate.getTime() : Number.MAX_SAFE_INTEGER;
+        return aTime - bTime;
+      });
+  }, [fixtures]);
 
   const toggleSetting = (key: keyof TeamSettings) => {
     setSettings((previousSettings) => ({
@@ -225,6 +269,115 @@ const ManageTeamScreen: React.FC = () => {
         return member;
       }),
     );
+  };
+
+  const parseKickoffInput = (value: string): string | null => {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return null;
+    }
+
+    const formatted = trimmed.includes('T') ? trimmed : trimmed.replace(' ', 'T');
+    const candidate = new Date(formatted);
+    if (Number.isNaN(candidate.getTime())) {
+      return null;
+    }
+
+    return candidate.toISOString();
+  };
+
+  const handleProposeFixture = () => {
+    const trimmedOpponent = fixtureOpponent.trim();
+    const trimmedLocation = fixtureLocation.trim();
+
+    if (!trimmedOpponent || !trimmedLocation) {
+      Alert.alert('Missing fixture details', 'Add an opponent and location to propose a match.');
+      return;
+    }
+
+    const optionIsoStrings = [fixtureOptionOne, fixtureOptionTwo]
+      .map((option) => parseKickoffInput(option))
+      .filter((option): option is string => Boolean(option));
+
+    if (optionIsoStrings.length === 0) {
+      Alert.alert(
+        'Add kickoff options',
+        'Provide at least one kickoff time using YYYY-MM-DD HH:MM (24hr) format.',
+      );
+      return;
+    }
+
+    dispatch(
+      proposeFixture({
+        teamId: route.params.teamId,
+        opponent: trimmedOpponent,
+        location: trimmedLocation,
+        kickoffOptions: optionIsoStrings,
+        notes: fixtureNotes.trim() || undefined,
+      }),
+    );
+
+    setFixtureOpponent('');
+    setFixtureLocation('');
+    setFixtureOptionOne('');
+    setFixtureOptionTwo('');
+    setFixtureNotes('');
+
+    Alert.alert('Fixture proposed', 'Your squad can now vote on the kickoff time.');
+  };
+
+  const handleVoteOnKickoff = (fixtureId: string, optionId: string) => {
+    dispatch(voteOnKickoff({ fixtureId, optionId }));
+    Alert.alert('Vote recorded', 'Your preference has been counted.');
+  };
+
+  const handleAcceptKickoff = (fixtureId: string, optionId: string) => {
+    dispatch(acceptFixtureKickoff({ fixtureId, optionId }));
+    Alert.alert('Kickoff locked in', 'Share the confirmed time with the opposition.');
+  };
+
+  const handleSyncFixture = (fixtureId: string) => {
+    dispatch(syncFixtureToCalendar({ fixtureId }));
+    Alert.alert('Calendar sync', 'The fixture has been marked as synced to device calendars.');
+  };
+
+  const handleRecordFixtureResult = (fixtureId: string, result: 'win' | 'loss' | 'draw') => {
+    dispatch(recordFixtureResult({ fixtureId, result }));
+    Alert.alert('Result saved', 'Team records on the Team screen have been updated.');
+  };
+
+  const handleCreateOpenPosition = () => {
+    const trimmedTitle = positionTitle.trim();
+    const trimmedDescription = positionDescription.trim();
+
+    if (!trimmedTitle || !trimmedDescription) {
+      Alert.alert('Add listing details', 'Describe the role and expectations before publishing.');
+      return;
+    }
+
+    dispatch(
+      createOpenPosition({
+        teamId: route.params.teamId,
+        position: trimmedTitle,
+        commitmentLevel: positionCommitment,
+        description: trimmedDescription,
+      }),
+    );
+
+    setPositionTitle('');
+    setPositionDescription('');
+    setPositionCommitment('competitive');
+
+    Alert.alert('Listing published', 'Free agents can now apply to join this spot.');
+  };
+
+  const handleUpdateListingStatus = (listingId: string, status: 'open' | 'inviting' | 'filled') => {
+    dispatch(updateOpenPositionStatus({ positionId: listingId, status }));
+  };
+
+  const handleInviteMarketplacePlayer = (freeAgentId: string, name: string) => {
+    dispatch(inviteFreeAgent({ freeAgentId, teamId: route.params.teamId }));
+    Alert.alert('Invite sent', `${name} has received your scouting invite.`);
   };
 
   const handleInviteFromContacts = () => {
@@ -565,6 +718,334 @@ const ManageTeamScreen: React.FC = () => {
         </View>
 
         <View style={styles.section}>
+          <Text style={styles.sectionTitle}>Match scheduling</Text>
+          <Text style={styles.sectionSubtitle}>
+            Propose fixtures, gather kickoff votes, and sync accepted matches to player calendars.
+          </Text>
+
+          <View style={styles.formField}>
+            <Text style={styles.label}>Opponent</Text>
+            <TextInput
+              value={fixtureOpponent}
+              onChangeText={setFixtureOpponent}
+              placeholder="e.g. West End Select"
+              style={styles.input}
+            />
+          </View>
+
+          <View style={styles.formField}>
+            <Text style={styles.label}>Location</Text>
+            <TextInput
+              value={fixtureLocation}
+              onChangeText={setFixtureLocation}
+              placeholder="Pitch or venue"
+              style={styles.input}
+            />
+          </View>
+
+          <View style={styles.formField}>
+            <Text style={styles.label}>Kickoff options</Text>
+            <TextInput
+              value={fixtureOptionOne}
+              onChangeText={setFixtureOptionOne}
+              placeholder="2024-07-14 19:30"
+              style={styles.input}
+            />
+            <TextInput
+              value={fixtureOptionTwo}
+              onChangeText={setFixtureOptionTwo}
+              placeholder="2024-07-15 18:00"
+              style={styles.input}
+            />
+            <Text style={styles.helperText}>Use 24-hour time (YYYY-MM-DD HH:MM).</Text>
+          </View>
+
+          <View style={styles.formField}>
+            <Text style={styles.label}>Notes</Text>
+            <TextInput
+              value={fixtureNotes}
+              onChangeText={setFixtureNotes}
+              placeholder="Share broadcast or parking details"
+              style={[styles.input, styles.multilineInput]}
+              multiline
+            />
+          </View>
+
+          <TouchableOpacity style={styles.primaryActionButton} onPress={handleProposeFixture}>
+            <Text style={styles.primaryActionButtonText}>Propose fixture</Text>
+          </TouchableOpacity>
+
+          <View style={styles.fixtureList}>
+            {sortedFixtures.length === 0 ? (
+              <Text style={styles.emptyState}>No fixtures yet. Start by proposing your first match.</Text>
+            ) : (
+              sortedFixtures.map((fixture) => {
+                const statusLabel =
+                  fixture.status === 'proposed'
+                    ? 'Awaiting votes'
+                    : fixture.status === 'scheduled'
+                    ? fixture.calendarSynced
+                      ? 'Synced to calendars'
+                      : 'Kickoff locked in'
+                    : fixture.result === 'win'
+                    ? 'Result: Win'
+                    : fixture.result === 'loss'
+                    ? 'Result: Loss'
+                    : 'Result: Draw';
+
+                const kickoffDate = getFixtureStartDate(fixture);
+                const kickoffLabel = kickoffDate
+                  ? kickoffDate.toLocaleString(undefined, {
+                      weekday: 'short',
+                      month: 'short',
+                      day: 'numeric',
+                      hour: '2-digit',
+                      minute: '2-digit',
+                    })
+                  : 'Kickoff to be confirmed';
+
+                return (
+                  <View key={fixture.id} style={styles.fixtureAdminCard}>
+                    <View style={styles.fixtureHeaderRow}>
+                      <View>
+                        <Text style={styles.fixtureHeading}>{fixture.opponent}</Text>
+                        <Text style={styles.fixtureSubheading}>{fixture.location}</Text>
+                        <Text style={styles.fixtureSubheading}>{kickoffLabel}</Text>
+                      </View>
+                      <Text style={styles.fixtureStatusPill}>{statusLabel}</Text>
+                    </View>
+
+                    {fixture.notes ? <Text style={styles.fixtureNotes}>{fixture.notes}</Text> : null}
+
+                    <View style={styles.kickoffOptionList}>
+                      {fixture.kickoffOptions.map((option) => {
+                        const isAccepted = fixture.acceptedKickoffOptionId === option.id;
+                        return (
+                          <View key={option.id} style={styles.kickoffOptionRow}>
+                            <View style={styles.kickoffOptionInfo}>
+                              <Text style={styles.kickoffOptionLabel}>{formatKickoffTime(option.isoTime)}</Text>
+                              <Text style={styles.kickoffOptionVotes}>{option.votes} votes</Text>
+                            </View>
+                            {fixture.status === 'proposed' ? (
+                              <View style={styles.kickoffOptionActions}>
+                                <TouchableOpacity
+                                  style={styles.secondaryChip}
+                                  onPress={() => handleVoteOnKickoff(fixture.id, option.id)}
+                                >
+                                  <Text style={styles.secondaryChipText}>Vote</Text>
+                                </TouchableOpacity>
+                                <TouchableOpacity
+                                  style={styles.secondaryChip}
+                                  onPress={() => handleAcceptKickoff(fixture.id, option.id)}
+                                >
+                                  <Text style={styles.secondaryChipText}>Accept</Text>
+                                </TouchableOpacity>
+                              </View>
+                            ) : isAccepted ? (
+                              <Text style={styles.acceptedLabel}>Chosen slot</Text>
+                            ) : null}
+                          </View>
+                        );
+                      })}
+                    </View>
+
+                    {fixture.status === 'scheduled' && !fixture.calendarSynced ? (
+                      <TouchableOpacity
+                        style={styles.secondaryChip}
+                        onPress={() => handleSyncFixture(fixture.id)}
+                      >
+                        <Text style={styles.secondaryChipText}>Mark as synced</Text>
+                      </TouchableOpacity>
+                    ) : null}
+
+                    {fixture.status === 'scheduled' ? (
+                      <View style={styles.resultActionBlock}>
+                        <Text style={styles.resultActionTitle}>Record result</Text>
+                        <View style={styles.resultActionRow}>
+                          <TouchableOpacity
+                            style={[styles.resultChip, styles.resultChipWin]}
+                            onPress={() => handleRecordFixtureResult(fixture.id, 'win')}
+                          >
+                            <Text style={styles.resultChipText}>Win</Text>
+                          </TouchableOpacity>
+                          <TouchableOpacity
+                            style={[styles.resultChip, styles.resultChipDraw]}
+                            onPress={() => handleRecordFixtureResult(fixture.id, 'draw')}
+                          >
+                            <Text style={styles.resultChipText}>Draw</Text>
+                          </TouchableOpacity>
+                          <TouchableOpacity
+                            style={[styles.resultChip, styles.resultChipLoss]}
+                            onPress={() => handleRecordFixtureResult(fixture.id, 'loss')}
+                          >
+                            <Text style={styles.resultChipText}>Loss</Text>
+                          </TouchableOpacity>
+                        </View>
+                      </View>
+                    ) : null}
+                  </View>
+                );
+              })
+            )}
+          </View>
+        </View>
+
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>Scouting marketplace</Text>
+          <Text style={styles.sectionSubtitle}>
+            Publish open positions, review interested free agents, and invite them with one tap.
+          </Text>
+
+          <View style={styles.formField}>
+            <Text style={styles.label}>Role headline</Text>
+            <TextInput
+              value={positionTitle}
+              onChangeText={setPositionTitle}
+              placeholder="e.g. Ball-playing centre back"
+              style={styles.input}
+            />
+          </View>
+
+          <View style={styles.formField}>
+            <Text style={styles.label}>Commitment</Text>
+            <View style={styles.commitmentToggle}>
+              {(['competitive', 'casual'] as const).map((level) => (
+                <TouchableOpacity
+                  key={level}
+                  style={[
+                    styles.commitmentPill,
+                    positionCommitment === level && styles.commitmentPillActive,
+                  ]}
+                  onPress={() => setPositionCommitment(level)}
+                >
+                  <Text
+                    style={[
+                      styles.commitmentPillText,
+                      positionCommitment === level && styles.commitmentPillTextActive,
+                    ]}
+                  >
+                    {level === 'competitive' ? 'Competitive' : 'Casual'}
+                  </Text>
+                </TouchableOpacity>
+              ))}
+            </View>
+          </View>
+
+          <View style={styles.formField}>
+            <Text style={styles.label}>Listing details</Text>
+            <TextInput
+              value={positionDescription}
+              onChangeText={setPositionDescription}
+              placeholder="Share playing style, availability windows, or perks"
+              style={[styles.input, styles.multilineInput]}
+              multiline
+            />
+          </View>
+
+          <TouchableOpacity style={styles.primaryActionButton} onPress={handleCreateOpenPosition}>
+            <Text style={styles.primaryActionButtonText}>Publish listing</Text>
+          </TouchableOpacity>
+
+          <View style={styles.marketplaceSection}>
+            <Text style={styles.marketplaceHeading}>Active listings</Text>
+            {openPositions.length === 0 ? (
+              <Text style={styles.emptyState}>No openings right now. Publish a listing above.</Text>
+            ) : (
+              openPositions.map((position) => {
+                const createdDate = new Date(position.createdAt);
+                return (
+                  <View key={position.id} style={styles.listingCard}>
+                    <View style={styles.listingHeader}>
+                      <Text style={styles.listingTitle}>{position.position}</Text>
+                      <Text style={styles.listingStatus}>{position.status.toUpperCase()}</Text>
+                    </View>
+                    <Text style={styles.listingMeta}>
+                      {position.commitmentLevel === 'competitive'
+                        ? 'Competitive weekly commitment'
+                        : 'Casual / flexible availability'}
+                    </Text>
+                    <Text style={styles.listingDescription}>{position.description}</Text>
+                    <Text style={styles.listingMeta}>
+                      Posted {createdDate.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })}
+                    </Text>
+                    <View style={styles.listingActions}>
+                      {position.status !== 'filled' ? (
+                        <TouchableOpacity
+                          style={styles.secondaryChip}
+                          onPress={() => handleUpdateListingStatus(position.id, 'filled')}
+                        >
+                          <Text style={styles.secondaryChipText}>Mark filled</Text>
+                        </TouchableOpacity>
+                      ) : null}
+                      {position.status === 'open' ? (
+                        <TouchableOpacity
+                          style={styles.secondaryChip}
+                          onPress={() => handleUpdateListingStatus(position.id, 'inviting')}
+                        >
+                          <Text style={styles.secondaryChipText}>Start inviting</Text>
+                        </TouchableOpacity>
+                      ) : null}
+                    </View>
+                  </View>
+                );
+              })
+            )}
+          </View>
+
+          <View style={styles.marketplaceSection}>
+            <Text style={styles.marketplaceHeading}>Recommended free agents</Text>
+            {marketplaceFreeAgents.length === 0 ? (
+              <Text style={styles.emptyState}>Marketplace is quiet right now. Check back soon.</Text>
+            ) : (
+              marketplaceFreeAgents.map((agent) => {
+                const alreadyInvited = agent.invitedByTeamIds.includes(route.params.teamId);
+                return (
+                  <View key={agent.id} style={styles.freeAgentCard}>
+                    <View style={styles.freeAgentHeader}>
+                      <View style={styles.freeAgentInfo}>
+                        <Text style={styles.freeAgentName}>{agent.name}</Text>
+                        <Text style={styles.freeAgentRole}>
+                          {agent.primaryPosition}
+                          {agent.secondaryPosition ? ` • ${agent.secondaryPosition}` : ''}
+                        </Text>
+                        <Text style={styles.freeAgentLocation}>{agent.location}</Text>
+                      </View>
+                      {alreadyInvited ? (
+                        <Text style={styles.invitedBadge}>Invited</Text>
+                      ) : (
+                        <TouchableOpacity
+                          style={styles.secondaryChip}
+                          onPress={() => handleInviteMarketplacePlayer(agent.id, agent.name)}
+                        >
+                          <Text style={styles.secondaryChipText}>Invite</Text>
+                        </TouchableOpacity>
+                      )}
+                    </View>
+                    <Text style={styles.freeAgentStrengths}>
+                      Key strengths: {agent.strengths.join(', ')}
+                    </Text>
+                    <View style={styles.socialRow}>
+                      {agent.socialHandles.instagram ? (
+                        <Text style={styles.socialHandle}>IG {agent.socialHandles.instagram}</Text>
+                      ) : null}
+                      {agent.socialHandles.twitter ? (
+                        <Text style={styles.socialHandle}>X {agent.socialHandles.twitter}</Text>
+                      ) : null}
+                      {agent.socialHandles.tiktok ? (
+                        <Text style={styles.socialHandle}>TikTok {agent.socialHandles.tiktok}</Text>
+                      ) : null}
+                    </View>
+                    {agent.highlightReelUrl ? (
+                      <Text style={styles.highlightLink}>{agent.highlightReelUrl}</Text>
+                    ) : null}
+                  </View>
+                );
+              })
+            )}
+          </View>
+        </View>
+
+        <View style={styles.section}>
           <Text style={styles.sectionTitle}>Challenge other teams</Text>
           <Text style={styles.sectionSubtitle}>
             Search nearby clubs or take on opponents from across the country.
@@ -785,6 +1266,14 @@ const styles = StyleSheet.create({
     paddingVertical: 12,
     fontSize: 16,
     backgroundColor: '#f8fafc',
+  },
+  multilineInput: {
+    minHeight: 96,
+    textAlignVertical: 'top',
+  },
+  helperText: {
+    fontSize: 12,
+    color: '#64748b',
   },
   searchInput: {
     flex: 1,
@@ -1024,6 +1513,245 @@ const styles = StyleSheet.create({
   usernameButtonText: {
     color: '#fff',
     fontWeight: '700',
+  },
+  primaryActionButton: {
+    backgroundColor: '#1d4ed8',
+    borderRadius: 12,
+    paddingVertical: 14,
+    alignItems: 'center',
+  },
+  primaryActionButtonText: {
+    color: '#fff',
+    fontWeight: '700',
+    fontSize: 16,
+  },
+  fixtureList: {
+    gap: 16,
+  },
+  fixtureAdminCard: {
+    borderWidth: 1,
+    borderColor: '#bfdbfe',
+    borderRadius: 16,
+    padding: 16,
+    gap: 12,
+    backgroundColor: '#f8fbff',
+  },
+  fixtureHeaderRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'flex-start',
+  },
+  fixtureHeading: {
+    fontSize: 16,
+    fontWeight: '700',
+    color: '#1d4ed8',
+  },
+  fixtureSubheading: {
+    color: '#1e293b',
+    fontSize: 13,
+  },
+  fixtureStatusPill: {
+    backgroundColor: '#1d4ed820',
+    color: '#1d4ed8',
+    fontWeight: '600',
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 999,
+    fontSize: 12,
+  },
+  fixtureNotes: {
+    fontSize: 13,
+    color: '#475569',
+  },
+  kickoffOptionList: {
+    gap: 12,
+  },
+  kickoffOptionRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  kickoffOptionInfo: {
+    gap: 4,
+  },
+  kickoffOptionLabel: {
+    fontWeight: '600',
+    color: '#1e293b',
+  },
+  kickoffOptionVotes: {
+    fontSize: 12,
+    color: '#64748b',
+  },
+  kickoffOptionActions: {
+    flexDirection: 'row',
+    gap: 8,
+  },
+  secondaryChip: {
+    backgroundColor: '#e0f2fe',
+    borderRadius: 999,
+    paddingHorizontal: 14,
+    paddingVertical: 8,
+  },
+  secondaryChipText: {
+    color: '#0369a1',
+    fontWeight: '600',
+  },
+  acceptedLabel: {
+    fontSize: 12,
+    color: '#047857',
+    fontWeight: '700',
+    textTransform: 'uppercase',
+  },
+  resultActionBlock: {
+    gap: 8,
+  },
+  resultActionTitle: {
+    fontSize: 13,
+    fontWeight: '600',
+    color: '#0f172a',
+  },
+  resultActionRow: {
+    flexDirection: 'row',
+    gap: 8,
+  },
+  resultChip: {
+    borderRadius: 999,
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+  },
+  resultChipWin: {
+    backgroundColor: '#dcfce7',
+  },
+  resultChipDraw: {
+    backgroundColor: '#e0f2fe',
+  },
+  resultChipLoss: {
+    backgroundColor: '#fee2e2',
+  },
+  resultChipText: {
+    fontWeight: '700',
+    color: '#0f172a',
+  },
+  commitmentToggle: {
+    flexDirection: 'row',
+    gap: 12,
+  },
+  commitmentPill: {
+    flex: 1,
+    borderWidth: 1,
+    borderColor: '#cbd5f5',
+    borderRadius: 12,
+    paddingVertical: 12,
+    alignItems: 'center',
+    backgroundColor: '#eef2ff',
+  },
+  commitmentPillActive: {
+    backgroundColor: '#312e81',
+    borderColor: '#312e81',
+  },
+  commitmentPillText: {
+    fontWeight: '600',
+    color: '#312e81',
+  },
+  commitmentPillTextActive: {
+    color: '#fff',
+  },
+  marketplaceSection: {
+    marginTop: 20,
+    gap: 12,
+  },
+  marketplaceHeading: {
+    fontSize: 15,
+    fontWeight: '700',
+    color: '#0f172a',
+  },
+  listingCard: {
+    borderWidth: 1,
+    borderColor: '#fcd34d',
+    borderRadius: 16,
+    padding: 16,
+    gap: 8,
+    backgroundColor: '#fffbeb',
+  },
+  listingHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  listingTitle: {
+    fontWeight: '700',
+    color: '#92400e',
+    fontSize: 15,
+  },
+  listingStatus: {
+    fontSize: 12,
+    color: '#d97706',
+    fontWeight: '700',
+  },
+  listingMeta: {
+    fontSize: 12,
+    color: '#b45309',
+  },
+  listingDescription: {
+    color: '#92400e',
+    fontSize: 13,
+  },
+  listingActions: {
+    flexDirection: 'row',
+    gap: 8,
+    flexWrap: 'wrap',
+  },
+  freeAgentCard: {
+    borderWidth: 1,
+    borderColor: '#bae6fd',
+    borderRadius: 16,
+    padding: 16,
+    gap: 8,
+    backgroundColor: '#f0f9ff',
+  },
+  freeAgentHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'flex-start',
+  },
+  freeAgentInfo: {
+    gap: 4,
+    flex: 1,
+  },
+  freeAgentName: {
+    fontWeight: '700',
+    color: '#0c4a6e',
+    fontSize: 15,
+  },
+  freeAgentRole: {
+    color: '#0c4a6e',
+    fontSize: 13,
+  },
+  freeAgentLocation: {
+    color: '#0369a1',
+    fontSize: 12,
+  },
+  invitedBadge: {
+    fontSize: 12,
+    fontWeight: '700',
+    color: '#16a34a',
+  },
+  freeAgentStrengths: {
+    fontSize: 13,
+    color: '#0c4a6e',
+  },
+  socialRow: {
+    flexDirection: 'row',
+    gap: 12,
+    flexWrap: 'wrap',
+  },
+  socialHandle: {
+    fontSize: 12,
+    color: '#0369a1',
+  },
+  highlightLink: {
+    color: '#1d4ed8',
+    fontSize: 12,
   },
   pitchInstructions: {
     marginTop: 12,

--- a/football-app/src/screens/ProfileScreen.tsx
+++ b/football-app/src/screens/ProfileScreen.tsx
@@ -68,6 +68,7 @@ import {
 import type { RootStackParamList } from '../types/navigation';
 import { detectBiometricSupport, requestBiometricAuthentication } from '../services/biometricAuth';
 import type { BiometricSupport } from '../services/biometricAuth';
+import { generateTrainingPlans } from '../services/trainingPlans';
 
 const sanitizeProfile = (profile: ProfileState): ProfileState => ({
   fullName: profile.fullName.trim(),
@@ -158,6 +159,10 @@ const ProfileScreen: React.FC = () => {
   const [checkingBiometricSupport, setCheckingBiometricSupport] = useState(false);
   const [biometricSupport, setBiometricSupport] = useState<BiometricSupport | null>(null);
   const [updatingBiometrics, setUpdatingBiometrics] = useState(false);
+  const trainingRecommendations = useMemo(
+    () => generateTrainingPlans(profileForm, premium.entitled),
+    [profileForm, premium.entitled],
+  );
 
   useEffect(() => {
     let mounted = true;
@@ -1086,6 +1091,47 @@ const ProfileScreen: React.FC = () => {
           )}
         </View>
 
+        <View style={styles.trainingSection}>
+          <Text style={styles.trainingHeading}>Personalised training plans</Text>
+          <Text style={styles.trainingSubtitle}>
+            Tailored sessions based on your profile, location, and premium access.
+          </Text>
+
+          {trainingRecommendations.unlocked.map((plan) => (
+            <View key={plan.id} style={styles.trainingCard}>
+              <View style={styles.trainingHeader}>
+                <Text style={styles.trainingTitle}>{plan.title}</Text>
+                <Text style={styles.trainingFocus}>{plan.focus.toUpperCase()}</Text>
+              </View>
+              <Text style={styles.trainingSummary}>{plan.summary}</Text>
+              <View style={styles.trainingTipList}>
+                {plan.tips.map((tip) => (
+                  <Text key={tip} style={styles.trainingTip}>
+                    • {tip}
+                  </Text>
+                ))}
+              </View>
+            </View>
+          ))}
+
+          {trainingRecommendations.locked.length > 0 ? (
+            <View style={styles.lockedTrainingCard}>
+              <Text style={styles.lockedTitle}>Premium-only insights</Text>
+              {trainingRecommendations.locked.map((plan) => (
+                <Text key={plan.id} style={styles.lockedSummary}>
+                  {plan.title} — unlock with Premium
+                </Text>
+              ))}
+              <TouchableOpacity
+                style={styles.lockedCta}
+                onPress={() => navigation.navigate('Profile')}
+              >
+                <Text style={styles.lockedCtaText}>View membership options</Text>
+              </TouchableOpacity>
+            </View>
+          ) : null}
+        </View>
+
         <View style={styles.walletCard}>
           <Text style={styles.walletLabel}>Wallet credits</Text>
           <Text style={styles.walletValue}>{walletSummary.balance}</Text>
@@ -1571,6 +1617,84 @@ const styles = StyleSheet.create({
   saveButtonText: {
     color: '#fff',
     fontWeight: '600',
+  },
+  trainingSection: {
+    marginTop: 24,
+    gap: 16,
+    backgroundColor: '#eef2ff',
+    borderRadius: 20,
+    padding: 20,
+  },
+  trainingHeading: {
+    fontSize: 18,
+    fontWeight: '700',
+    color: '#1d4ed8',
+  },
+  trainingSubtitle: {
+    fontSize: 13,
+    color: '#1e3a8a',
+  },
+  trainingCard: {
+    backgroundColor: '#fff',
+    borderRadius: 16,
+    padding: 16,
+    gap: 10,
+    borderWidth: 1,
+    borderColor: '#c7d2fe',
+  },
+  trainingHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  trainingTitle: {
+    fontSize: 15,
+    fontWeight: '700',
+    color: '#1d4ed8',
+  },
+  trainingFocus: {
+    fontSize: 12,
+    fontWeight: '700',
+    color: '#4338ca',
+  },
+  trainingSummary: {
+    color: '#1e293b',
+    fontSize: 13,
+  },
+  trainingTipList: {
+    gap: 4,
+  },
+  trainingTip: {
+    color: '#1e293b',
+    fontSize: 12,
+  },
+  lockedTrainingCard: {
+    backgroundColor: '#ede9fe',
+    borderRadius: 16,
+    padding: 16,
+    gap: 8,
+  },
+  lockedTitle: {
+    fontSize: 14,
+    fontWeight: '700',
+    color: '#4c1d95',
+  },
+  lockedSummary: {
+    fontSize: 12,
+    color: '#4c1d95',
+  },
+  lockedCta: {
+    marginTop: 8,
+    alignSelf: 'flex-start',
+    borderRadius: 999,
+    backgroundColor: '#4c1d95',
+    paddingHorizontal: 18,
+    paddingVertical: 10,
+  },
+  lockedCtaText: {
+    color: '#fff',
+    fontWeight: '700',
+    fontSize: 12,
   },
   walletCard: {
     backgroundColor: '#f3f4f6',

--- a/football-app/src/screens/TournamentScreen.tsx
+++ b/football-app/src/screens/TournamentScreen.tsx
@@ -1,11 +1,12 @@
 import React, { useCallback, useEffect, useMemo } from 'react';
-import { StyleSheet, View, Text, Button, Alert } from 'react-native';
+import { StyleSheet, View, Text, Button, Alert, TouchableOpacity } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useRewardedAd } from 'react-native-google-mobile-ads';
 
 import { tournamentRewardedAdUnitId } from '../config/ads';
 import { useAppDispatch, useAppSelector } from '../store/hooks';
-import { creditWallet } from '../store/slices/walletSlice';
+import { creditWallet, debitWallet } from '../store/slices/walletSlice';
+import { enrolInTier, selectTournamentSeason } from '../store/slices/tournamentsSlice';
 
 const FALLBACK_REWARD_AMOUNT = 5;
 
@@ -13,6 +14,7 @@ const TournamentScreen: React.FC = () => {
   const dispatch = useAppDispatch();
   const credits = useAppSelector((state) => state.wallet.credits);
   const isPremium = useAppSelector((state) => state.premium.entitled);
+  const season = useAppSelector(selectTournamentSeason);
   const requestOptions = useMemo(() => ({ requestNonPersonalizedAdsOnly: true }), []);
   const { isLoaded, isClosed, load, show, reward, error } = useRewardedAd(
     tournamentRewardedAdUnitId,
@@ -52,6 +54,17 @@ const TournamentScreen: React.FC = () => {
     }
   }, [error]);
 
+  const handleJoinTier = (tierId: string, requiredCredits: number, tierName: string) => {
+    if (credits < requiredCredits) {
+      Alert.alert('Not enough credits', 'Earn more credits to unlock this ladder tier.');
+      return;
+    }
+
+    dispatch(debitWallet(requiredCredits));
+    dispatch(enrolInTier({ tierId }));
+    Alert.alert('Enrolled', `You are now competing in the ${tierName}. Good luck!`);
+  };
+
   return (
     <SafeAreaView style={styles.safeArea}>
       <View style={styles.content}>
@@ -70,17 +83,80 @@ const TournamentScreen: React.FC = () => {
           )}
         </View>
 
+        <View style={styles.ladderSection}>
+          <Text style={styles.ladderTitle}>{season.seasonLabel}</Text>
+          <Text style={styles.ladderSubtitle}>
+            Promotion and relegation across three competitive tiers keeps every fixture meaningful.
+          </Text>
+
+          {season.currentStanding ? (
+            <View style={styles.standingCard}>
+              <Text style={styles.standingTitle}>Current standing</Text>
+              <Text style={styles.standingMeta}>
+                Tier: {season.ladderTiers.find((tier) => tier.id === season.currentStanding?.tierId)?.name ?? '—'}
+              </Text>
+              <Text style={styles.standingMeta}>
+                Position {season.currentStanding.position} • {season.currentStanding.points} pts
+              </Text>
+              <Text style={styles.standingMeta}>
+                W{season.currentStanding.wins} D{season.currentStanding.draws} L{season.currentStanding.losses} • GD {season.currentStanding.goalDifference}
+              </Text>
+            </View>
+          ) : null}
+
+          <View style={styles.tierList}>
+            {season.ladderTiers.map((tier) => {
+              const isActive = season.enrolledTierId === tier.id;
+              return (
+                <View
+                  key={tier.id}
+                  style={[styles.tierCard, isActive && styles.tierCardActive]}
+                >
+                  <View style={styles.tierHeader}>
+                    <Text style={styles.tierName}>{tier.name}</Text>
+                    <Text style={styles.tierCredits}>{tier.requiredCredits} credits</Text>
+                  </View>
+                  <Text style={styles.tierDescription}>{tier.description}</Text>
+                  <Text style={styles.tierMeta}>
+                    Promotion {tier.promotionSlots} • Relegation {tier.relegationSlots}
+                  </Text>
+                  <View style={styles.tierInsights}>
+                    {tier.analyticsHighlights.map((highlight) => (
+                      <Text key={highlight} style={styles.tierInsightBullet}>
+                        • {highlight}
+                      </Text>
+                    ))}
+                  </View>
+                  {isActive ? (
+                    <Text style={styles.activeBadge}>Currently enrolled</Text>
+                  ) : (
+                    <TouchableOpacity
+                      style={styles.joinButton}
+                      onPress={() => handleJoinTier(tier.id, tier.requiredCredits, tier.name)}
+                    >
+                      <Text style={styles.joinButtonText}>Join tier</Text>
+                    </TouchableOpacity>
+                  )}
+                </View>
+              );
+            })}
+          </View>
+        </View>
+
         {isPremium ? (
           <View style={styles.premiumInsights}>
             <Text style={styles.premiumInsightsTitle}>Premium tournament insights</Text>
-            <Text style={styles.premiumInsightsDetail}>Next best event: Elite Cup (opens in 3 days)</Text>
-            <Text style={styles.premiumInsightsDetail}>Recommended entry fee budget: 120 credits</Text>
+            {season.recentInsights.slice(0, 3).map((insight) => (
+              <Text key={insight} style={styles.premiumInsightsDetail}>
+                {insight}
+              </Text>
+            ))}
           </View>
         ) : (
           <View style={styles.premiumUpsell}>
             <Text style={styles.premiumUpsellText}>
-              Premium members get tournament recommendations tailored to their squad. Unlock from
-              the Profile screen.
+              Premium members unlock live ladder analytics, opponent scouting, and workload trends.
+              Activate your membership from the Profile screen.
             </Text>
           </View>
         )}
@@ -146,6 +222,100 @@ const styles = StyleSheet.create({
   premiumInsightsDetail: {
     fontSize: 13,
     color: '#3f6212',
+  },
+  ladderSection: {
+    marginTop: 24,
+    padding: 20,
+    borderRadius: 16,
+    backgroundColor: '#f0fdf4',
+    gap: 16,
+  },
+  ladderTitle: {
+    fontSize: 20,
+    fontWeight: '700',
+    color: '#166534',
+  },
+  ladderSubtitle: {
+    fontSize: 13,
+    color: '#166534',
+  },
+  standingCard: {
+    borderRadius: 12,
+    padding: 16,
+    backgroundColor: '#dcfce7',
+    gap: 4,
+  },
+  standingTitle: {
+    fontSize: 14,
+    fontWeight: '700',
+    color: '#166534',
+  },
+  standingMeta: {
+    fontSize: 12,
+    color: '#166534',
+  },
+  tierList: {
+    gap: 16,
+  },
+  tierCard: {
+    borderRadius: 16,
+    borderWidth: 1,
+    borderColor: '#bbf7d0',
+    backgroundColor: '#ffffff',
+    padding: 16,
+    gap: 10,
+  },
+  tierCardActive: {
+    borderColor: '#16a34a',
+    shadowColor: '#16a34a',
+    shadowOpacity: 0.2,
+    shadowRadius: 12,
+    shadowOffset: { width: 0, height: 4 },
+    elevation: 3,
+  },
+  tierHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  tierName: {
+    fontSize: 16,
+    fontWeight: '700',
+    color: '#166534',
+  },
+  tierCredits: {
+    color: '#047857',
+    fontWeight: '700',
+  },
+  tierDescription: {
+    color: '#14532d',
+    fontSize: 13,
+  },
+  tierMeta: {
+    fontSize: 12,
+    color: '#15803d',
+  },
+  tierInsights: {
+    gap: 4,
+  },
+  tierInsightBullet: {
+    fontSize: 12,
+    color: '#15803d',
+  },
+  joinButton: {
+    borderRadius: 999,
+    backgroundColor: '#16a34a',
+    paddingVertical: 10,
+    alignItems: 'center',
+  },
+  joinButtonText: {
+    color: '#fff',
+    fontWeight: '700',
+  },
+  activeBadge: {
+    fontSize: 12,
+    fontWeight: '700',
+    color: '#16a34a',
   },
   premiumUpsell: {
     marginTop: 24,

--- a/football-app/src/services/trainingPlans.ts
+++ b/football-app/src/services/trainingPlans.ts
@@ -1,0 +1,147 @@
+import type { ProfileState } from '../store/slices/profileSlice';
+
+export interface TrainingPlanRecommendation {
+  id: string;
+  title: string;
+  summary: string;
+  focus: 'fitness' | 'technical' | 'tactical' | 'wellness';
+  premiumOnly?: boolean;
+  tips: string[];
+}
+
+const determineAge = (profile: ProfileState): number | null => {
+  if (!profile.dateOfBirth) {
+    return null;
+  }
+
+  const segments = profile.dateOfBirth.split('/');
+  if (segments.length !== 3) {
+    return null;
+  }
+
+  const [day, month, year] = segments.map((segment) => Number(segment));
+  if (Number.isNaN(day) || Number.isNaN(month) || Number.isNaN(year)) {
+    return null;
+  }
+
+  const birthDate = new Date(year, month - 1, day);
+  if (Number.isNaN(birthDate.getTime())) {
+    return null;
+  }
+
+  const diff = Date.now() - birthDate.getTime();
+  const ageDate = new Date(diff);
+  return Math.abs(ageDate.getUTCFullYear() - 1970);
+};
+
+const inferClimateFocus = (country: string): string => {
+  const lowerCaseCountry = country.trim().toLowerCase();
+
+  if (['england', 'scotland', 'ireland', 'wales', 'united kingdom', 'uk'].includes(lowerCaseCountry)) {
+    return 'Expect wet weather: prioritise grip work and quick transitions on slick surfaces.';
+  }
+
+  if (['spain', 'portugal', 'italy', 'greece'].includes(lowerCaseCountry)) {
+    return 'Prepare for heat management with hydration windows every 20 minutes.';
+  }
+
+  if (lowerCaseCountry.length === 0) {
+    return 'Use general-purpose training with adjustable indoor and outdoor variations.';
+  }
+
+  return 'Adapt conditioning to your local climate and pitch availability.';
+};
+
+export const generateTrainingPlans = (
+  profile: ProfileState,
+  isPremium: boolean,
+): { unlocked: TrainingPlanRecommendation[]; locked: TrainingPlanRecommendation[] } => {
+  const age = determineAge(profile);
+  const climateNote = inferClimateFocus(profile.address.country);
+
+  const basePlans: TrainingPlanRecommendation[] = [
+    {
+      id: 'plan-fitness',
+      title: 'Matchday Conditioning Routine',
+      summary: 'High-intensity interval plan to keep legs fresh for 90 minutes.',
+      focus: 'fitness',
+      tips: [
+        'Complete 4x4 minute tempo runs with 90 second recovery jogs.',
+        'Add resisted sprints to mimic pressing triggers late in games.',
+        climateNote,
+      ],
+    },
+    {
+      id: 'plan-technical',
+      title: 'Small-sided Technical Circuit',
+      summary: 'Sharpen your first touch, passing lanes, and under-pressure decision making.',
+      focus: 'technical',
+      tips: [
+        'Set up 4-station rondos emphasising one-touch play for 90 seconds per station.',
+        'Progress to 5v3 overload games encouraging forward runs from midfield.',
+      ],
+    },
+    {
+      id: 'plan-wellness',
+      title: 'Recovery & Wellness Toolkit',
+      summary: 'Regain freshness between fixtures with mobility, nutrition, and sleep anchors.',
+      focus: 'wellness',
+      tips: [
+        'Log 10 minutes of guided mobility targeting hips and hamstrings every evening.',
+        'Prioritise slow-release carbs and 25g protein in the two hours post match.',
+      ],
+    },
+  ];
+
+  if (age && age >= 32) {
+    basePlans.push({
+      id: 'plan-longevity',
+      title: 'Longevity Primer',
+      summary: 'Support joint health and reduce soft-tissue injuries.',
+      focus: 'wellness',
+      tips: [
+        'Include twice-weekly eccentric strength blocks for hamstrings and calves.',
+        'Schedule an extra low-impact conditioning day (pool or bike).',
+      ],
+    });
+  }
+
+  const premiumPlans: TrainingPlanRecommendation[] = [
+    {
+      id: 'plan-analytics',
+      title: 'Premium Analytics Breakdown',
+      summary: 'Unlock GPS workload comparisons against teams in your ladder tier.',
+      focus: 'tactical',
+      premiumOnly: true,
+      tips: [
+        'Overlay sprint maps from last three fixtures and identify fatigue drop-offs.',
+        'Use positional heatmaps to rebalance workload across the midfield trio.',
+        'Automate trend reports to coaching staff after each matchday.',
+      ],
+    },
+    {
+      id: 'plan-nutrition',
+      title: 'Personalised Nutrition Windows',
+      summary: 'Timed fuelling guidance aligned to your kickoff slots.',
+      focus: 'wellness',
+      premiumOnly: true,
+      tips: [
+        'Consume 30g of carbohydrates 30 minutes prior to training on late kickoffs.',
+        'Utilise tart cherry supplementation during congested fixture weeks.',
+      ],
+    },
+  ];
+
+  const unlocked = [...basePlans];
+  const locked: TrainingPlanRecommendation[] = [];
+
+  premiumPlans.forEach((plan) => {
+    if (isPremium) {
+      unlocked.push(plan);
+    } else {
+      locked.push(plan);
+    }
+  });
+
+  return { unlocked, locked };
+};

--- a/football-app/src/store/index.ts
+++ b/football-app/src/store/index.ts
@@ -4,6 +4,10 @@ import teamsReducer from './slices/teamsSlice';
 import walletReducer from './slices/walletSlice';
 import premiumReducer from './slices/premiumSlice';
 import profileReducer from './slices/profileSlice';
+import scheduleReducer from './slices/scheduleSlice';
+import scoutingReducer from './slices/scoutingSlice';
+import tournamentsReducer from './slices/tournamentsSlice';
+import challengesReducer from './slices/challengesSlice';
 import { authReducer } from './slices/authSlice';
 import { adminReducer } from './slices/adminSlice';
 
@@ -13,6 +17,10 @@ export const store = configureStore({
     wallet: walletReducer,
     premium: premiumReducer,
     profile: profileReducer,
+    schedule: scheduleReducer,
+    scouting: scoutingReducer,
+    tournaments: tournamentsReducer,
+    challenges: challengesReducer,
     auth: authReducer,
     admin: adminReducer,
 

--- a/football-app/src/store/slices/challengesSlice.ts
+++ b/football-app/src/store/slices/challengesSlice.ts
@@ -1,0 +1,80 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+import type { RootState } from '..';
+
+export type ChallengeStatus = 'available' | 'completed' | 'claimed';
+
+export type ChallengeReward =
+  | { type: 'credits'; amount: number }
+  | { type: 'badge'; name: string };
+
+export interface Challenge {
+  id: string;
+  title: string;
+  description: string;
+  status: ChallengeStatus;
+  reward: ChallengeReward;
+  expiresAt: string;
+}
+
+export interface ChallengesState {
+  challenges: Challenge[];
+}
+
+const initialState: ChallengesState = {
+  challenges: [
+    {
+      id: 'challenge-1',
+      title: 'Precision Passing Drill',
+      description: 'Complete 40 successful wall passes in under 5 minutes and upload your clip.',
+      status: 'available',
+      reward: { type: 'credits', amount: 10 },
+      expiresAt: new Date(Date.now() + 1000 * 60 * 60 * 24 * 3).toISOString(),
+    },
+    {
+      id: 'challenge-2',
+      title: 'Weekly Fitness Check-in',
+      description: 'Log three recovery sessions in your wellness journal.',
+      status: 'available',
+      reward: { type: 'badge', name: 'Wellness Warrior' },
+      expiresAt: new Date(Date.now() + 1000 * 60 * 60 * 24 * 5).toISOString(),
+    },
+    {
+      id: 'challenge-3',
+      title: 'Set-piece Strategy Review',
+      description: 'Upload your planned corner routine and tag two teammates for feedback.',
+      status: 'completed',
+      reward: { type: 'credits', amount: 20 },
+      expiresAt: new Date(Date.now() + 1000 * 60 * 60 * 24).toISOString(),
+    },
+  ],
+};
+
+const challengesSlice = createSlice({
+  name: 'challenges',
+  initialState,
+  reducers: {
+    markChallengeCompleted: (state, action: PayloadAction<{ challengeId: string }>) => {
+      const challenge = state.challenges.find((item) => item.id === action.payload.challengeId);
+      if (!challenge || challenge.status !== 'available') {
+        return;
+      }
+
+      challenge.status = 'completed';
+    },
+    claimChallengeReward: (state, action: PayloadAction<{ challengeId: string }>) => {
+      const challenge = state.challenges.find((item) => item.id === action.payload.challengeId);
+      if (!challenge || challenge.status !== 'completed') {
+        return;
+      }
+
+      challenge.status = 'claimed';
+    },
+  },
+});
+
+export const { markChallengeCompleted, claimChallengeReward } = challengesSlice.actions;
+
+export const selectActiveChallenges = (state: RootState): Challenge[] => state.challenges.challenges;
+
+export default challengesSlice.reducer;

--- a/football-app/src/store/slices/scheduleSlice.ts
+++ b/football-app/src/store/slices/scheduleSlice.ts
@@ -1,0 +1,306 @@
+import { createSlice, nanoid, PayloadAction } from '@reduxjs/toolkit';
+
+import type { RootState } from '..';
+
+export type FixtureStatus = 'proposed' | 'scheduled' | 'completed';
+export type FixtureResult = 'win' | 'loss' | 'draw';
+
+export interface KickoffOption {
+  id: string;
+  isoTime: string;
+  votes: number;
+}
+
+export interface Fixture {
+  id: string;
+  teamId: string;
+  opponent: string;
+  location: string;
+  status: FixtureStatus;
+  kickoffOptions: KickoffOption[];
+  acceptedKickoffOptionId: string | null;
+  calendarSynced: boolean;
+  result: FixtureResult | null;
+  notes?: string;
+  lastUpdated: string;
+}
+
+export interface ScheduleState {
+  fixtures: Fixture[];
+}
+
+const initialState: ScheduleState = {
+  fixtures: [
+    {
+      id: 'fixture-1',
+      teamId: 'team-1',
+      opponent: 'East London Rovers',
+      location: 'Hackney Marshes Pitch 7',
+      status: 'scheduled',
+      kickoffOptions: [
+        {
+          id: 'fixture-1-slot-1',
+          isoTime: new Date().toISOString(),
+          votes: 5,
+        },
+        {
+          id: 'fixture-1-slot-2',
+          isoTime: new Date(Date.now() + 1000 * 60 * 60 * 24).toISOString(),
+          votes: 3,
+        },
+      ],
+      acceptedKickoffOptionId: 'fixture-1-slot-1',
+      calendarSynced: false,
+      result: null,
+      notes: 'League fixture to decide top seed heading into playoffs.',
+      lastUpdated: new Date().toISOString(),
+    },
+    {
+      id: 'fixture-2',
+      teamId: 'team-1',
+      opponent: 'Northside United',
+      location: 'Riverbank Arena',
+      status: 'completed',
+      kickoffOptions: [
+        {
+          id: 'fixture-2-slot-1',
+          isoTime: new Date(Date.now() - 1000 * 60 * 60 * 24 * 7).toISOString(),
+          votes: 7,
+        },
+      ],
+      acceptedKickoffOptionId: 'fixture-2-slot-1',
+      calendarSynced: true,
+      result: 'win',
+      notes: 'Comfortable 3-1 victory with a rotated side.',
+      lastUpdated: new Date(Date.now() - 1000 * 60 * 60 * 24 * 3).toISOString(),
+    },
+    {
+      id: 'fixture-3',
+      teamId: 'team-2',
+      opponent: 'Southbank Saints',
+      location: 'Waterloo Park',
+      status: 'proposed',
+      kickoffOptions: [
+        {
+          id: 'fixture-3-slot-1',
+          isoTime: new Date(Date.now() + 1000 * 60 * 60 * 48).toISOString(),
+          votes: 2,
+        },
+        {
+          id: 'fixture-3-slot-2',
+          isoTime: new Date(Date.now() + 1000 * 60 * 60 * 72).toISOString(),
+          votes: 5,
+        },
+      ],
+      acceptedKickoffOptionId: null,
+      calendarSynced: false,
+      result: null,
+      notes: 'Cup quarter-final proposal awaiting captain confirmation.',
+      lastUpdated: new Date().toISOString(),
+    },
+  ],
+};
+
+const findFixture = (state: ScheduleState, fixtureId: string) =>
+  state.fixtures.find((fixture) => fixture.id === fixtureId);
+
+const scheduleSlice = createSlice({
+  name: 'schedule',
+  initialState,
+  reducers: {
+    proposeFixture: (
+      state,
+      action: PayloadAction<{
+        teamId: string;
+        opponent: string;
+        location: string;
+        kickoffOptions: string[];
+        notes?: string;
+      }>,
+    ) => {
+      const { teamId, opponent, location, kickoffOptions, notes } = action.payload;
+      const now = new Date().toISOString();
+
+      const fixture: Fixture = {
+        id: nanoid(),
+        teamId,
+        opponent,
+        location,
+        status: 'proposed',
+        kickoffOptions: kickoffOptions.map((iso) => ({
+          id: nanoid(),
+          isoTime: iso,
+          votes: 0,
+        })),
+        acceptedKickoffOptionId: null,
+        calendarSynced: false,
+        result: null,
+        notes,
+        lastUpdated: now,
+      };
+
+      state.fixtures.unshift(fixture);
+    },
+    voteOnKickoff: (
+      state,
+      action: PayloadAction<{ fixtureId: string; optionId: string }>,
+    ) => {
+      const { fixtureId, optionId } = action.payload;
+      const fixture = findFixture(state, fixtureId);
+
+      if (!fixture || fixture.status !== 'proposed') {
+        return;
+      }
+
+      const option = fixture.kickoffOptions.find((item) => item.id === optionId);
+      if (!option) {
+        return;
+      }
+
+      option.votes += 1;
+      fixture.lastUpdated = new Date().toISOString();
+    },
+    acceptFixtureKickoff: (
+      state,
+      action: PayloadAction<{ fixtureId: string; optionId: string }>,
+    ) => {
+      const { fixtureId, optionId } = action.payload;
+      const fixture = findFixture(state, fixtureId);
+
+      if (!fixture) {
+        return;
+      }
+
+      const optionExists = fixture.kickoffOptions.some((option) => option.id === optionId);
+      if (!optionExists) {
+        return;
+      }
+
+      fixture.acceptedKickoffOptionId = optionId;
+      fixture.status = 'scheduled';
+      fixture.lastUpdated = new Date().toISOString();
+    },
+    syncFixtureToCalendar: (state, action: PayloadAction<{ fixtureId: string }>) => {
+      const fixture = findFixture(state, action.payload.fixtureId);
+      if (!fixture) {
+        return;
+      }
+
+      fixture.calendarSynced = true;
+      fixture.lastUpdated = new Date().toISOString();
+    },
+    recordFixtureResult: (
+      state,
+      action: PayloadAction<{ fixtureId: string; result: FixtureResult }>,
+    ) => {
+      const { fixtureId, result } = action.payload;
+      const fixture = findFixture(state, fixtureId);
+
+      if (!fixture) {
+        return;
+      }
+
+      fixture.result = result;
+      fixture.status = 'completed';
+      fixture.lastUpdated = new Date().toISOString();
+    },
+  },
+});
+
+export const {
+  proposeFixture,
+  voteOnKickoff,
+  acceptFixtureKickoff,
+  syncFixtureToCalendar,
+  recordFixtureResult,
+} = scheduleSlice.actions;
+
+export const selectFixturesByTeam = (state: RootState, teamId: string): Fixture[] =>
+  state.schedule.fixtures.filter((fixture) => fixture.teamId === teamId);
+
+export const selectNextFixtureForTeam = (
+  state: RootState,
+  teamId: string,
+): Fixture | undefined => {
+  const fixtures = selectFixturesByTeam(state, teamId).filter(
+    (fixture) => fixture.status === 'scheduled' || fixture.status === 'proposed',
+  );
+
+  return fixtures
+    .slice()
+    .sort((a, b) => {
+      const aDate = getFixtureStartDate(a);
+      const bDate = getFixtureStartDate(b);
+      if (!aDate && !bDate) {
+        return 0;
+      }
+      if (!aDate) {
+        return 1;
+      }
+      if (!bDate) {
+        return -1;
+      }
+      return aDate.getTime() - bDate.getTime();
+    })
+    .shift();
+};
+
+export const selectTeamRecord = (
+  state: RootState,
+  teamId: string,
+): { wins: number; draws: number; losses: number } => {
+  const fixtures = selectFixturesByTeam(state, teamId);
+  return fixtures.reduce(
+    (record, fixture) => {
+      if (fixture.status === 'completed' && fixture.result) {
+        if (fixture.result === 'win') {
+          record.wins += 1;
+        } else if (fixture.result === 'loss') {
+          record.losses += 1;
+        } else {
+          record.draws += 1;
+        }
+      }
+
+      return record;
+    },
+    { wins: 0, draws: 0, losses: 0 },
+  );
+};
+
+export const getFixtureStartDate = (fixture: Fixture): Date | null => {
+  if (fixture.status === 'completed') {
+    const option = fixture.kickoffOptions.find((item) => item.id === fixture.acceptedKickoffOptionId);
+    return option ? new Date(option.isoTime) : null;
+  }
+
+  if (fixture.status === 'scheduled' && fixture.acceptedKickoffOptionId) {
+    const option = fixture.kickoffOptions.find((item) => item.id === fixture.acceptedKickoffOptionId);
+    return option ? new Date(option.isoTime) : null;
+  }
+
+  const proposed = fixture.kickoffOptions.slice().sort((a, b) => {
+    const aTime = new Date(a.isoTime).getTime();
+    const bTime = new Date(b.isoTime).getTime();
+    return aTime - bTime;
+  });
+
+  return proposed.length > 0 ? new Date(proposed[0].isoTime) : null;
+};
+
+export const formatKickoffTime = (isoTime: string): string => {
+  const date = new Date(isoTime);
+  if (Number.isNaN(date.getTime())) {
+    return isoTime;
+  }
+
+  return date.toLocaleString(undefined, {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+};
+
+export default scheduleSlice.reducer;

--- a/football-app/src/store/slices/scoutingSlice.ts
+++ b/football-app/src/store/slices/scoutingSlice.ts
@@ -1,0 +1,158 @@
+import { createSlice, nanoid, PayloadAction } from '@reduxjs/toolkit';
+
+import type { RootState } from '..';
+
+export type OpenPositionStatus = 'open' | 'inviting' | 'filled';
+
+export interface OpenPosition {
+  id: string;
+  teamId: string;
+  position: string;
+  commitmentLevel: 'casual' | 'competitive';
+  description: string;
+  status: OpenPositionStatus;
+  createdAt: string;
+}
+
+export interface FreeAgentProfile {
+  id: string;
+  name: string;
+  primaryPosition: string;
+  secondaryPosition?: string;
+  location: string;
+  strengths: string[];
+  socialHandles: {
+    instagram?: string;
+    twitter?: string;
+    tiktok?: string;
+  };
+  highlightReelUrl?: string;
+  invitedByTeamIds: string[];
+}
+
+export interface ScoutingState {
+  openPositions: OpenPosition[];
+  freeAgents: FreeAgentProfile[];
+}
+
+const initialState: ScoutingState = {
+  openPositions: [
+    {
+      id: 'position-1',
+      teamId: 'team-1',
+      position: 'Ball playing centre-back',
+      commitmentLevel: 'competitive',
+      description: 'Weekly training on Tuesdays, fixtures on Sundays. Comfortable in a back three.',
+      status: 'inviting',
+      createdAt: new Date(Date.now() - 1000 * 60 * 60 * 24 * 2).toISOString(),
+    },
+    {
+      id: 'position-2',
+      teamId: 'team-2',
+      position: 'Impact winger',
+      commitmentLevel: 'casual',
+      description: 'Ideal for a pacey wide player who enjoys 7-a-side weeknights.',
+      status: 'open',
+      createdAt: new Date(Date.now() - 1000 * 60 * 60 * 24 * 6).toISOString(),
+    },
+  ],
+  freeAgents: [
+    {
+      id: 'free-agent-1',
+      name: 'Jordan Mensah',
+      primaryPosition: 'Forward',
+      secondaryPosition: 'Winger',
+      location: 'London, UK',
+      strengths: ['Explosive pace', 'Clinical finishing', 'Pressing from the front'],
+      socialHandles: {
+        instagram: '@jordmensah',
+        twitter: '@jordmensah9',
+      },
+      highlightReelUrl: 'https://highlights.football/jordanmensah',
+      invitedByTeamIds: ['team-1'],
+    },
+    {
+      id: 'free-agent-2',
+      name: 'Amelia Rossi',
+      primaryPosition: 'Goalkeeper',
+      location: 'Manchester, UK',
+      strengths: ['Penalty specialist', 'Commands the box', 'Distribution under pressure'],
+      socialHandles: {
+        instagram: '@amelia.rossi',
+      },
+      invitedByTeamIds: [],
+    },
+    {
+      id: 'free-agent-3',
+      name: 'Nina Osei',
+      primaryPosition: 'Midfielder',
+      secondaryPosition: 'Full-back',
+      location: 'Birmingham, UK',
+      strengths: ['Two-footed', 'Reads the game', 'Durable'],
+      socialHandles: {
+        tiktok: '@ninaosei',
+      },
+      invitedByTeamIds: [],
+    },
+  ],
+};
+
+const scoutingSlice = createSlice({
+  name: 'scouting',
+  initialState,
+  reducers: {
+    createOpenPosition: (
+      state,
+      action: PayloadAction<{
+        teamId: string;
+        position: string;
+        commitmentLevel: 'casual' | 'competitive';
+        description: string;
+      }>,
+    ) => {
+      const { teamId, position, commitmentLevel, description } = action.payload;
+      state.openPositions.unshift({
+        id: nanoid(),
+        teamId,
+        position,
+        commitmentLevel,
+        description,
+        status: 'open',
+        createdAt: new Date().toISOString(),
+      });
+    },
+    updateOpenPositionStatus: (
+      state,
+      action: PayloadAction<{ positionId: string; status: OpenPositionStatus }>,
+    ) => {
+      const listing = state.openPositions.find((position) => position.id === action.payload.positionId);
+      if (!listing) {
+        return;
+      }
+
+      listing.status = action.payload.status;
+    },
+    inviteFreeAgent: (
+      state,
+      action: PayloadAction<{ freeAgentId: string; teamId: string }>,
+    ) => {
+      const profile = state.freeAgents.find((agent) => agent.id === action.payload.freeAgentId);
+      if (!profile) {
+        return;
+      }
+
+      if (!profile.invitedByTeamIds.includes(action.payload.teamId)) {
+        profile.invitedByTeamIds.push(action.payload.teamId);
+      }
+    },
+  },
+});
+
+export const { createOpenPosition, updateOpenPositionStatus, inviteFreeAgent } = scoutingSlice.actions;
+
+export const selectOpenPositionsForTeam = (state: RootState, teamId: string): OpenPosition[] =>
+  state.scouting.openPositions.filter((position) => position.teamId === teamId);
+
+export const selectFreeAgents = (state: RootState): FreeAgentProfile[] => state.scouting.freeAgents;
+
+export default scoutingSlice.reducer;

--- a/football-app/src/store/slices/tournamentsSlice.ts
+++ b/football-app/src/store/slices/tournamentsSlice.ts
@@ -1,0 +1,135 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+import type { RootState } from '..';
+
+export interface LadderTier {
+  id: string;
+  name: string;
+  description: string;
+  requiredCredits: number;
+  promotionSlots: number;
+  relegationSlots: number;
+  analyticsHighlights: string[];
+}
+
+export interface LadderStanding {
+  tierId: string;
+  position: number;
+  matchesPlayed: number;
+  wins: number;
+  draws: number;
+  losses: number;
+  goalDifference: number;
+  points: number;
+  trend: 'up' | 'steady' | 'down';
+}
+
+export interface TournamentSeasonState {
+  seasonLabel: string;
+  ladderTiers: LadderTier[];
+  currentStanding: LadderStanding | null;
+  enrolledTierId: string | null;
+  recentInsights: string[];
+}
+
+const initialState: TournamentSeasonState = {
+  seasonLabel: 'Spring 2024 Ladder',
+  ladderTiers: [
+    {
+      id: 'tier-elite',
+      name: 'Elite Championship',
+      description: 'Top tier clubs battling for continental qualification and cash prizes.',
+      requiredCredits: 150,
+      promotionSlots: 0,
+      relegationSlots: 3,
+      analyticsHighlights: [
+        'Opponents average 2.1 goals scored per match',
+        'High pressing teams concede 23% fewer shots on target',
+      ],
+    },
+    {
+      id: 'tier-competitive',
+      name: 'Competitive Division',
+      description: 'Ambitious squads pushing for promotion into the elite championship.',
+      requiredCredits: 90,
+      promotionSlots: 3,
+      relegationSlots: 3,
+      analyticsHighlights: [
+        'Wing play accounts for 41% of assists in this tier',
+        'Teams with 60%+ availability win 70% of fixtures',
+      ],
+    },
+    {
+      id: 'tier-community',
+      name: 'Community League',
+      description: 'Friendly fixtures with flexible scheduling and live match support.',
+      requiredCredits: 40,
+      promotionSlots: 4,
+      relegationSlots: 0,
+      analyticsHighlights: [
+        'Average kickoff time: Saturday 1:30pm',
+        'Teams with consistent weekly attendance gain +8 goal difference',
+      ],
+    },
+  ],
+  currentStanding: {
+    tierId: 'tier-competitive',
+    position: 3,
+    matchesPlayed: 8,
+    wins: 5,
+    draws: 2,
+    losses: 1,
+    goalDifference: 9,
+    points: 17,
+    trend: 'up',
+  },
+  enrolledTierId: 'tier-competitive',
+  recentInsights: [
+    'Opposition scouts flagged your transition defence as an opportunity. Consider reinforcing midfield cover.',
+    'Premium telemetry shows your forwards outperforming the league xG by 12%.',
+  ],
+};
+
+const tournamentsSlice = createSlice({
+  name: 'tournaments',
+  initialState,
+  reducers: {
+    enrolInTier: (state, action: PayloadAction<{ tierId: string }>) => {
+      const tier = state.ladderTiers.find((item) => item.id === action.payload.tierId);
+      if (!tier) {
+        return;
+      }
+
+      state.enrolledTierId = tier.id;
+      state.currentStanding = {
+        tierId: tier.id,
+        position: tier.id === 'tier-elite' ? 8 : 12,
+        matchesPlayed: 0,
+        wins: 0,
+        draws: 0,
+        losses: 0,
+        goalDifference: 0,
+        points: 0,
+        trend: 'steady',
+      };
+      state.recentInsights.unshift(
+        `Joined ${tier.name}. Live analytics will activate after your first two fixtures.`,
+      );
+    },
+    updateStanding: (state, action: PayloadAction<LadderStanding>) => {
+      state.currentStanding = action.payload;
+    },
+    addInsight: (state, action: PayloadAction<string>) => {
+      state.recentInsights.unshift(action.payload);
+    },
+  },
+});
+
+export const { enrolInTier, updateStanding, addInsight } = tournamentsSlice.actions;
+
+export const selectTournamentSeason = (state: RootState): TournamentSeasonState => state.tournaments;
+
+export const selectTierById = (state: RootState, tierId: string): LadderTier | undefined =>
+  state.tournaments.ladderTiers.find((tier) => tier.id === tierId);
+
+export default tournamentsSlice.reducer;

--- a/football-app/src/store/slices/walletSlice.ts
+++ b/football-app/src/store/slices/walletSlice.ts
@@ -15,9 +15,17 @@ const walletSlice = createSlice({
     creditWallet: (state: WalletState, action: PayloadAction<number>) => {
       state.credits += action.payload;
     },
+    debitWallet: (state: WalletState, action: PayloadAction<number>) => {
+      const amount = Math.max(0, action.payload);
+      if (amount === 0) {
+        return;
+      }
+
+      state.credits = Math.max(0, state.credits - amount);
+    },
   },
 });
 
-export const { creditWallet } = walletSlice.actions;
+export const { creditWallet, debitWallet } = walletSlice.actions;
 
 export default walletSlice.reducer;


### PR DESCRIPTION
## Summary
- add Redux slices covering match scheduling, scouting marketplace, seasonal ladders, and community challenges with supporting utilities
- extend team, manage team, home, tournament, and profile screens with scheduling workflows, scouting invites, ladder enrolment, and personalised training guidance
- enhance team cards and wallet handling to surface records, upcoming fixtures, and credit debits when joining tiers

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e5acc26588832e81cbd6c66a1c60a3