### PR TITLE
Add team communication strategy recommendations

### DIFF
--- a/docs/team-communication-strategy.md
+++ b/docs/team-communication-strategy.md
@@ -1,0 +1,38 @@
+# Team Communication Strategy
+
+## Current Product Understanding
+- **Home experience** welcomes users, personalizes the greeting for signed-in members, and routes into the major areas of the app while surfacing a banner ad placement.
+- **Team management** pulls roster data from Redux, allows members to remove or manage teams, and highlights premium-only analytics when the user lacks entitlement.
+- **Tournament participation** hinges on rewarded ads that top up wallet credits and unlock premium insights once the user has sufficient access.
+- **Profile hub** collects detailed personal data, marketing preferences, wallet packages, and premium purchase flows, persisting everything locally when the capability exists.
+
+These areas form the backbone for the feature work already in flight—match scheduling, scouting marketplace, seasonal ladders, community challenges, and contextual training guidance.
+
+## Recommendation: Layered Team Communication
+A dedicated chat surface can complement the in-progress features, but it should be scoped to match the workflows captains already manage inside the app. Rather than launching a generic messenger, consider a layered approach:
+
+1. **Matchday Threads**
+   - Auto-create threads for each scheduled fixture so coaches can confirm availability, share lineups, and pin logistics.
+   - Attach match metadata (opponent, venue, kickoff time) directly from the scheduling module so conversations stay contextual.
+
+2. **Team Announcement Channel**
+   - Provide a one-to-many broadcast space where coaches or admins can push urgent updates (training cancellations, arrival reminders).
+   - Allow reactions or quick acknowledgement buttons to gauge team readiness without cluttering the thread.
+
+3. **Direct Messages and Small Groups (Phase 2)**
+   - After validating engagement, extend messaging to player-to-player or staff subgroups for tactical discussions.
+   - Gate advanced capabilities (large media uploads, unlimited message history) behind premium to reinforce the existing entitlement model.
+
+### Implementation Considerations
+- **Push notifications & reminders:** Use the existing notification infrastructure to surface unread messages and matchday alerts.
+- **Moderation & safety:** Offer basic moderation controls (delete, mute, report) before opening broader chats, especially if youth teams participate.
+- **Offline support:** Cache recent messages locally to ensure captains can review logistics even without a stable connection.
+- **Ad & premium strategy:** Sponsored tips or premium-only tactical libraries can be embedded in match threads, aligning with the monetization pattern already present in tournaments and the profile wallet.
+
+## Alternatives & Complements
+If a full chat rollout feels heavy, explore lighter-weight communication features first:
+- **Availability Polls:** Let captains request simple yes/no/maybe responses for training or match attendance, feeding the scheduling module.
+- **Automated Summaries:** Generate post-match recaps (result, player of the match, wallet credit changes) and publish them to a shared feed.
+- **Integrations:** Provide quick-share to WhatsApp/Telegram for teams that already coordinate externally, while capturing feedback to iterate on native chat.
+
+Starting with contextual messaging tied to scheduling delivers the highest immediate value and creates a natural upgrade path toward richer, premium-ready communication tools.


### PR DESCRIPTION
## Summary
- document the current product understanding across home, team, tournament, and profile flows
- recommend a layered roadmap for team communication capabilities rooted in matchday needs
- outline implementation considerations and lightweight alternatives to a full chat launch

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68e5aa888858832ea66fdca5d76f297b