### PR TITLE
Add profile email field and stabilise contact saving

### DIFF
--- a/football-app/src/store/slices/profileSlice.ts
+++ b/football-app/src/store/slices/profileSlice.ts
@@ -30,6 +30,7 @@ export const PROFILE_PAYMENT_METHODS: readonly ProfilePaymentMethod[] = [
 export interface ProfileState {
   fullName: string;
   displayName: string;
+  email: string;
   mobileNumber: string;
   dateOfBirth: string;
   bio: string;
@@ -49,6 +50,7 @@ export type ProfileUpdate = Partial<
 const initialState: ProfileState = {
   fullName: '',
   displayName: '',
+  email: '',
   mobileNumber: '',
   dateOfBirth: '',
   bio: '',


### PR DESCRIPTION
## Summary
- extend the profile state to include a persisted contact email field
- normalise email/mobile values during save and prefill the email from the signed-in user
- add an editable email input to the profile screen and keep local state in sync after saving

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e5b15de4fc832e8c4e0791c5d4d47c