### PR TITLE
Fix Manage Team screen runtime errors

### DIFF
--- a/football-app/src/screens/ManageTeamScreen.tsx
+++ b/football-app/src/screens/ManageTeamScreen.tsx
@@ -43,6 +43,11 @@ import {
   selectOpenPositionsForTeam,
   updateOpenPositionStatus,
 } from '../store/slices/scoutingSlice';
+import {
+  DiscoveredTeam,
+  TeamDiscoveryScope,
+  searchTeams,
+} from '../services/teamDiscovery';
 
 type ManageTeamRouteProp = RouteProp<RootStackParamList, 'ManageTeam'>;
 type ManageTeamNavigationProp = NativeStackNavigationProp<RootStackParamList, 'ManageTeam'>;
@@ -108,6 +113,11 @@ const ManageTeamScreen: React.FC = () => {
     'competitive',
   );
   const [positionDescription, setPositionDescription] = useState('');
+  const [searchScope, setSearchScope] = useState<TeamDiscoveryScope>('local');
+  const [teamSearchQuery, setTeamSearchQuery] = useState('');
+  const [searchResults, setSearchResults] = useState<DiscoveredTeam[]>([]);
+  const [isSearchingTeams, setIsSearchingTeams] = useState(false);
+  const [searchError, setSearchError] = useState<string | null>(null);
 
   useEffect(() => {
     if (team) {


### PR DESCRIPTION
## Summary
- import the team discovery helpers into ManageTeamScreen
- initialize the discovery search state so the Manage Team screen loads correctly

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e5b24d1388832ebfa2b0cf1c5a68bc