### PR TITLE
Add team communication planning tools

### DIFF
--- a/football-app/src/components/TeamCard.tsx
+++ b/football-app/src/components/TeamCard.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { StyleSheet, Text, View, TouchableOpacity } from 'react-native';
 
 import type { Team } from '../store/slices/teamsSlice';
+import type { CommunicationStatus } from '../store/slices/communicationsSlice';
 
 interface TeamRecordSummary {
   wins: number;
@@ -15,6 +16,11 @@ interface TeamCardProps {
   onManage: () => void;
   record?: TeamRecordSummary;
   nextFixtureLabel?: string;
+  latestCommunication?: {
+    title: string;
+    status: CommunicationStatus;
+    timestamp: string | null;
+  };
 }
 
 
@@ -24,8 +30,23 @@ const TeamCard: React.FC<TeamCardProps> = ({
   onManage,
   record,
   nextFixtureLabel,
+  latestCommunication,
 }) => {
   const hasRecord = record && (record.wins > 0 || record.draws > 0 || record.losses > 0);
+  const communicationTimestampLabel = latestCommunication?.timestamp
+    ? new Date(latestCommunication.timestamp).toLocaleString(undefined, {
+        weekday: 'short',
+        month: 'short',
+        day: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit',
+      })
+    : null;
+  const communicationHeading = latestCommunication
+    ? latestCommunication.status === 'scheduled'
+      ? 'Next update'
+      : 'Latest update'
+    : null;
 
   return (
     <View style={styles.card}>
@@ -45,6 +66,18 @@ const TeamCard: React.FC<TeamCardProps> = ({
         <View style={styles.fixtureRow}>
           <Text style={styles.fixtureLabel}>Next kickoff</Text>
           <Text style={styles.fixtureValue}>{nextFixtureLabel}</Text>
+        </View>
+      ) : null}
+
+      {latestCommunication ? (
+        <View style={styles.communicationRow}>
+          {communicationHeading ? (
+            <Text style={styles.communicationLabel}>{communicationHeading}</Text>
+          ) : null}
+          <Text style={styles.communicationTitle}>{latestCommunication.title}</Text>
+          {communicationTimestampLabel ? (
+            <Text style={styles.communicationMeta}>{communicationTimestampLabel}</Text>
+          ) : null}
         </View>
       ) : null}
 
@@ -113,6 +146,29 @@ const styles = StyleSheet.create({
   fixtureValue: {
     fontSize: 14,
     color: '#1e293b',
+  },
+  communicationRow: {
+    marginTop: 12,
+    backgroundColor: '#f1f5f9',
+    borderRadius: 10,
+    padding: 12,
+    gap: 4,
+  },
+  communicationLabel: {
+    fontSize: 12,
+    color: '#0369a1',
+    fontWeight: '700',
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+  },
+  communicationTitle: {
+    fontSize: 14,
+    color: '#0f172a',
+    fontWeight: '600',
+  },
+  communicationMeta: {
+    fontSize: 12,
+    color: '#475569',
   },
   actions: {
     flexDirection: 'row',

--- a/football-app/src/screens/ManageTeamScreen.tsx
+++ b/football-app/src/screens/ManageTeamScreen.tsx
@@ -43,11 +43,84 @@ import {
   selectOpenPositionsForTeam,
   updateOpenPositionStatus,
 } from '../store/slices/scoutingSlice';
+import {
+  CommunicationAudience,
+  CommunicationCategory,
+  CommunicationChannel,
+  recordCommunicationResponse,
+  scheduleCommunication,
+  selectCommunicationStatsForTeam,
+  selectCommunicationsForTeam,
+  selectUpcomingCommunicationsForTeam,
+  updateCommunicationStatus,
+} from '../store/slices/communicationsSlice';
+import type { DiscoveredTeam, TeamDiscoveryScope } from '../services/teamDiscovery';
+import { searchTeams } from '../services/teamDiscovery';
 
 type ManageTeamRouteProp = RouteProp<RootStackParamList, 'ManageTeam'>;
 type ManageTeamNavigationProp = NativeStackNavigationProp<RootStackParamList, 'ManageTeam'>;
 
 const TEAM_ROLES: TeamRole[] = ['Goalkeeper', 'Defender', 'Midfielder', 'Forward', 'Substitute'];
+
+const COMMUNICATION_CATEGORIES: {
+  value: CommunicationCategory;
+  label: string;
+  helper: string;
+}[] = [
+  {
+    value: 'announcement',
+    label: 'Announcement',
+    helper: 'Great for weekly touchpoints, training reminders, and community news.',
+  },
+  {
+    value: 'logistics',
+    label: 'Logistics',
+    helper: 'Share travel details, meeting points, and kit colours before matchday.',
+  },
+  {
+    value: 'lineup',
+    label: 'Lineup',
+    helper: 'Reveal the starting eleven and rotation plans once votes are collected.',
+  },
+  {
+    value: 'celebration',
+    label: 'Celebration',
+    helper: 'Recognise player milestones and post-match highlights to boost morale.',
+  },
+];
+
+const COMMUNICATION_CHANNELS: { value: CommunicationChannel; label: string }[] = [
+  { value: 'push', label: 'Push' },
+  { value: 'email', label: 'Email' },
+  { value: 'sms', label: 'SMS' },
+];
+
+const COMMUNICATION_AUDIENCES: {
+  value: CommunicationAudience;
+  label: string;
+  helper: string;
+}[] = [
+  {
+    value: 'everyone',
+    label: 'Whole squad',
+    helper: 'Send to every registered teammate for maximum visibility.',
+  },
+  {
+    value: 'captains',
+    label: 'Captains & staff',
+    helper: 'Target decision makers to align on tactics or club admin tasks.',
+  },
+  {
+    value: 'availablePlayers',
+    label: 'Available players',
+    helper: 'Nudge the players who marked themselves free for the next fixture.',
+  },
+  {
+    value: 'trialists',
+    label: 'Trialists',
+    helper: 'Keep prospects engaged with onboarding tips and schedule updates.',
+  },
+];
 
 const determineDefaultRole = (index: number): TeamRole => {
   if (index === 0) {
@@ -108,6 +181,50 @@ const ManageTeamScreen: React.FC = () => {
     'competitive',
   );
   const [positionDescription, setPositionDescription] = useState('');
+  const [communicationTitle, setCommunicationTitle] = useState('');
+  const [communicationMessage, setCommunicationMessage] = useState('');
+  const [communicationCategory, setCommunicationCategory] =
+    useState<CommunicationCategory>('announcement');
+  const [communicationAudience, setCommunicationAudience] =
+    useState<CommunicationAudience>('everyone');
+  const [communicationChannels, setCommunicationChannels] = useState<CommunicationChannel[]>([
+    'push',
+    'email',
+  ]);
+  const [communicationSchedule, setCommunicationSchedule] = useState('');
+  const [communicationReminderEnabled, setCommunicationReminderEnabled] = useState(true);
+  const [communicationRequiresResponse, setCommunicationRequiresResponse] = useState(false);
+  const [teamSearchQuery, setTeamSearchQuery] = useState('');
+  const [searchScope, setSearchScope] = useState<TeamDiscoveryScope>('local');
+  const [searchResults, setSearchResults] = useState<DiscoveredTeam[]>([]);
+  const [isSearchingTeams, setIsSearchingTeams] = useState(false);
+  const [searchError, setSearchError] = useState<string | null>(null);
+  const communications = useAppSelector((state) =>
+    selectCommunicationsForTeam(state, route.params.teamId),
+  );
+  const upcomingCommunications = useAppSelector((state) =>
+    selectUpcomingCommunicationsForTeam(state, route.params.teamId),
+  );
+  const communicationStats = useAppSelector((state) =>
+    selectCommunicationStatsForTeam(state, route.params.teamId),
+  );
+  const latestSentCommunication = useMemo(() => {
+    return communications.find((communication) => communication.status === 'sent') ?? null;
+  }, [communications]);
+  const lastCommunicationSummary = useMemo(() => {
+    if (!communicationStats.lastSentAt) {
+      return 'No updates sent yet — start with an availability check-in.';
+    }
+
+    const date = new Date(communicationStats.lastSentAt);
+    return `Last update sent ${date.toLocaleString(undefined, {
+      weekday: 'short',
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    })}`;
+  }, [communicationStats.lastSentAt]);
 
   useEffect(() => {
     if (team) {
@@ -292,6 +409,92 @@ const ManageTeamScreen: React.FC = () => {
     }
 
     return candidate.toISOString();
+  };
+
+  const handleToggleCommunicationChannel = (channel: CommunicationChannel) => {
+    setCommunicationChannels((previous) => {
+      if (previous.includes(channel)) {
+        return previous.filter((value) => value !== channel);
+      }
+
+      return [...previous, channel];
+    });
+  };
+
+  const handlePlanCommunication = () => {
+    if (!route.params?.teamId) {
+      Alert.alert('Select a team', 'Create and save your team before sending updates.');
+      return;
+    }
+
+    const trimmedTitle = communicationTitle.trim();
+    const trimmedMessage = communicationMessage.trim();
+
+    if (!trimmedTitle || !trimmedMessage) {
+      Alert.alert('Add communication details', 'Include a title and message before sending.');
+      return;
+    }
+
+    if (communicationChannels.length === 0) {
+      Alert.alert('Select channels', 'Pick at least one delivery channel for this update.');
+      return;
+    }
+
+    let scheduledIso: string | null = null;
+    if (communicationSchedule.trim()) {
+      const parsed = parseKickoffInput(communicationSchedule);
+      if (!parsed) {
+        Alert.alert('Invalid time', 'Use YYYY-MM-DD HH:MM (24hr) when scheduling an update.');
+        return;
+      }
+
+      scheduledIso = parsed;
+    }
+
+    dispatch(
+      scheduleCommunication({
+        teamId: route.params.teamId,
+        title: trimmedTitle,
+        body: trimmedMessage,
+        category: communicationCategory,
+        audience: communicationAudience,
+        channels: communicationChannels,
+        scheduledFor: scheduledIso,
+        followUpReminderMinutes: communicationReminderEnabled ? 1440 : null,
+        requiresResponse: communicationRequiresResponse,
+        expectedResponders: communicationRequiresResponse ? members.length : 0,
+      }),
+    );
+
+    if (scheduledIso) {
+      Alert.alert('Update scheduled', 'We will deliver this message at the selected time.');
+    } else {
+      Alert.alert('Update sent', 'Your squad will receive the announcement immediately.');
+    }
+
+    setCommunicationTitle('');
+    setCommunicationMessage('');
+    setCommunicationSchedule('');
+    setCommunicationRequiresResponse(false);
+  };
+
+  const handleMarkCommunicationSent = (communicationId: string) => {
+    dispatch(updateCommunicationStatus({ id: communicationId, status: 'sent' }));
+    Alert.alert('Marked as sent', 'The communication timeline has been updated.');
+  };
+
+  const handleLogCommunicationResponse = (
+    communicationId: string,
+    response: 'confirmed' | 'declined',
+  ) => {
+    dispatch(recordCommunicationResponse({ id: communicationId, response }));
+
+    Alert.alert(
+      'Response logged',
+      response === 'confirmed'
+        ? 'Confirmation added. Keep nudging remaining players if needed.'
+        : 'Decline recorded. Adjust your lineup or follow up with them directly.',
+    );
   };
 
   const handleProposeFixture = () => {
@@ -740,6 +943,292 @@ const ManageTeamScreen: React.FC = () => {
               value={settings.autoCollectMatchStats}
               onValueChange={() => toggleSetting('autoCollectMatchStats')}
             />
+          </View>
+        </View>
+
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>Team communication</Text>
+          <Text style={styles.sectionSubtitle}>
+            Coordinate announcements, automate reminders, and capture squad feedback in one place.
+          </Text>
+
+          <View style={styles.communicationSummaryCard}>
+            <View style={styles.communicationSummaryRow}>
+              <View style={styles.communicationMetric}>
+                <Text style={styles.communicationMetricValue}>{communicationStats.sent}</Text>
+                <Text style={styles.communicationMetricLabel}>Sent</Text>
+              </View>
+              <View style={styles.communicationMetric}>
+                <Text style={styles.communicationMetricValue}>{communicationStats.upcoming}</Text>
+                <Text style={styles.communicationMetricLabel}>Scheduled</Text>
+              </View>
+              <View style={styles.communicationMetric}>
+                <Text style={styles.communicationMetricValue}>
+                  {communicationStats.averageResponseRate}%
+                </Text>
+                <Text style={styles.communicationMetricLabel}>Avg. response</Text>
+              </View>
+            </View>
+            <Text style={styles.communicationSummaryFooter}>{lastCommunicationSummary}</Text>
+            {latestSentCommunication ? (
+              <Text style={styles.communicationSummaryHighlight}>
+                Latest: {latestSentCommunication.title}
+              </Text>
+            ) : null}
+          </View>
+
+          <View style={styles.formField}>
+            <Text style={styles.label}>Template</Text>
+            <View style={styles.communicationChipRow}>
+              {COMMUNICATION_CATEGORIES.map((category) => {
+                const isActive = communicationCategory === category.value;
+                return (
+                  <TouchableOpacity
+                    key={category.value}
+                    style={[
+                      styles.communicationChip,
+                      isActive && styles.communicationChipActive,
+                    ]}
+                    onPress={() => setCommunicationCategory(category.value)}
+                  >
+                    <Text
+                      style={[
+                        styles.communicationChipText,
+                        isActive && styles.communicationChipTextActive,
+                      ]}
+                    >
+                      {category.label}
+                    </Text>
+                  </TouchableOpacity>
+                );
+              })}
+            </View>
+            <Text style={styles.helperText}>
+              {COMMUNICATION_CATEGORIES.find((category) => category.value === communicationCategory)
+                ?.helper || ''}
+            </Text>
+          </View>
+
+          <View style={styles.formField}>
+            <Text style={styles.label}>Headline</Text>
+            <TextInput
+              value={communicationTitle}
+              onChangeText={setCommunicationTitle}
+              placeholder="e.g. Availability for Saturday"
+              style={styles.input}
+            />
+          </View>
+
+          <View style={[styles.formField, styles.communicationMessageField]}>
+            <Text style={styles.label}>Message</Text>
+            <TextInput
+              value={communicationMessage}
+              onChangeText={setCommunicationMessage}
+              placeholder="Cover kickoff time, travel plans, and kit colours."
+              style={[styles.input, styles.multilineInput]}
+              multiline
+            />
+          </View>
+
+          <View style={styles.formField}>
+            <Text style={styles.label}>Audience</Text>
+            <View style={styles.communicationAudienceList}>
+              {COMMUNICATION_AUDIENCES.map((audience) => {
+                const isActive = communicationAudience === audience.value;
+                return (
+                  <TouchableOpacity
+                    key={audience.value}
+                    style={[
+                      styles.communicationAudienceCard,
+                      isActive && styles.communicationAudienceCardActive,
+                    ]}
+                    onPress={() => setCommunicationAudience(audience.value)}
+                  >
+                    <Text style={styles.communicationAudienceTitle}>{audience.label}</Text>
+                    <Text
+                      style={[
+                        styles.communicationAudienceDescription,
+                        isActive && styles.communicationAudienceDescriptionActive,
+                      ]}
+                    >
+                      {audience.helper}
+                    </Text>
+                  </TouchableOpacity>
+                );
+              })}
+            </View>
+          </View>
+
+          <View style={styles.formField}>
+            <Text style={styles.label}>Channels</Text>
+            <View style={styles.communicationChannelRow}>
+              {COMMUNICATION_CHANNELS.map((channel) => {
+                const isActive = communicationChannels.includes(channel.value);
+                return (
+                  <TouchableOpacity
+                    key={channel.value}
+                    style={[
+                      styles.communicationChannelChip,
+                      isActive && styles.communicationChannelChipActive,
+                    ]}
+                    onPress={() => handleToggleCommunicationChannel(channel.value)}
+                  >
+                    <Text
+                      style={[
+                        styles.communicationChannelChipText,
+                        isActive && styles.communicationChannelChipTextActive,
+                      ]}
+                    >
+                      {channel.label}
+                    </Text>
+                  </TouchableOpacity>
+                );
+              })}
+            </View>
+            <Text style={styles.helperText}>Select one or more channels for delivery.</Text>
+          </View>
+
+          <View style={styles.formField}>
+            <Text style={styles.label}>Send time (optional)</Text>
+            <TextInput
+              value={communicationSchedule}
+              onChangeText={setCommunicationSchedule}
+              placeholder="2024-07-18 19:30"
+              style={styles.input}
+            />
+            <Text style={styles.helperText}>Leave blank to send immediately.</Text>
+          </View>
+
+          <View style={styles.communicationToggleRow}>
+            <View style={styles.communicationToggleText}>
+              <Text style={styles.settingLabel}>Schedule reminder</Text>
+              <Text style={styles.settingDescription}>
+                We'll nudge teammates 24 hours before the event when this is enabled.
+              </Text>
+            </View>
+            <Switch
+              value={communicationReminderEnabled}
+              onValueChange={setCommunicationReminderEnabled}
+            />
+          </View>
+
+          <View style={styles.communicationToggleRow}>
+            <View style={styles.communicationToggleText}>
+              <Text style={styles.settingLabel}>Require RSVP</Text>
+              <Text style={styles.settingDescription}>
+                Track confirmations from {members.length} teammates and keep absences visible.
+              </Text>
+            </View>
+            <Switch
+              value={communicationRequiresResponse}
+              onValueChange={setCommunicationRequiresResponse}
+            />
+          </View>
+
+          <TouchableOpacity style={styles.primaryActionButton} onPress={handlePlanCommunication}>
+            <Text style={styles.primaryActionButtonText}>
+              {communicationSchedule.trim() ? 'Schedule update' : 'Send update'}
+            </Text>
+          </TouchableOpacity>
+
+          <View style={styles.communicationTimeline}>
+            <Text style={styles.timelineHeading}>Upcoming messages</Text>
+            {upcomingCommunications.length === 0 ? (
+              <Text style={styles.emptyState}>
+                No scheduled updates yet. Plan one so nobody misses vital information.
+              </Text>
+            ) : (
+              upcomingCommunications.map((communication) => (
+                <View key={communication.id} style={styles.timelineCard}>
+                  <Text style={styles.timelineTitle}>{communication.title}</Text>
+                  <Text style={styles.timelineMeta}>
+                    {communication.scheduledFor
+                      ? new Date(communication.scheduledFor).toLocaleString(undefined, {
+                          weekday: 'short',
+                          month: 'short',
+                          day: 'numeric',
+                          hour: '2-digit',
+                          minute: '2-digit',
+                        })
+                      : 'Send manually'}
+                  </Text>
+                  <Text style={styles.timelineMeta}>
+                    Channels: {communication.channels.join(', ')}
+                  </Text>
+                  <TouchableOpacity
+                    style={styles.secondaryChip}
+                    onPress={() => handleMarkCommunicationSent(communication.id)}
+                  >
+                    <Text style={styles.secondaryChipText}>Mark as sent</Text>
+                  </TouchableOpacity>
+                </View>
+              ))
+            )}
+          </View>
+
+          <View style={styles.communicationTimeline}>
+            <Text style={styles.timelineHeading}>Recent delivery</Text>
+            {communications.filter((communication) => communication.status === 'sent').length === 0 ? (
+              <Text style={styles.emptyState}>
+                Send your first message to begin tracking player responses.
+              </Text>
+            ) : (
+              communications
+                .filter((communication) => communication.status === 'sent')
+                .slice(0, 3)
+                .map((communication) => {
+                  const audienceLabel =
+                    COMMUNICATION_AUDIENCES.find((audience) => audience.value === communication.audience)
+                      ?.label ?? communication.audience;
+                  return (
+                    <View key={communication.id} style={styles.timelineCard}>
+                      <Text style={styles.timelineTitle}>{communication.title}</Text>
+                      <Text style={styles.timelineMeta}>
+                        Sent{' '}
+                        {new Date(communication.createdAt).toLocaleString(undefined, {
+                          weekday: 'short',
+                          month: 'short',
+                          day: 'numeric',
+                          hour: '2-digit',
+                          minute: '2-digit',
+                        })}
+                      </Text>
+                      <Text style={styles.timelineMeta}>Audience: {audienceLabel}</Text>
+                      {communication.requiresResponse ? (
+                        <>
+                          <View style={styles.responseRow}>
+                            <Text style={styles.responseStat}>
+                              {communication.responseSummary.confirmed} confirmed
+                            </Text>
+                            <Text style={styles.responseStat}>
+                              {communication.responseSummary.declined} declined
+                            </Text>
+                            <Text style={styles.responseStat}>
+                              {communication.responseSummary.awaiting} awaiting
+                            </Text>
+                          </View>
+                          <View style={styles.responseActions}>
+                            <TouchableOpacity
+                              style={[styles.secondaryChip, styles.responseActionChip]}
+                              onPress={() => handleLogCommunicationResponse(communication.id, 'confirmed')}
+                            >
+                              <Text style={styles.secondaryChipText}>Log confirm</Text>
+                            </TouchableOpacity>
+                            <TouchableOpacity
+                              style={[styles.secondaryChip, styles.responseActionChip]}
+                              onPress={() => handleLogCommunicationResponse(communication.id, 'declined')}
+                            >
+                              <Text style={styles.secondaryChipText}>Log decline</Text>
+                            </TouchableOpacity>
+                          </View>
+                        </>
+                      ) : (
+                        <Text style={styles.timelineMeta}>No RSVP required for this update.</Text>
+                      )}
+                    </View>
+                  );
+                })
+            )}
           </View>
         </View>
 
@@ -1300,6 +1789,178 @@ const styles = StyleSheet.create({
   helperText: {
     fontSize: 12,
     color: '#64748b',
+  },
+  communicationSummaryCard: {
+    backgroundColor: '#eef2ff',
+    borderRadius: 16,
+    padding: 16,
+    borderWidth: 1,
+    borderColor: '#c7d2fe',
+    gap: 12,
+  },
+  communicationSummaryRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    gap: 12,
+  },
+  communicationMetric: {
+    flex: 1,
+    alignItems: 'center',
+    paddingVertical: 8,
+    borderRadius: 12,
+    backgroundColor: '#fff',
+  },
+  communicationMetricValue: {
+    fontSize: 18,
+    fontWeight: '700',
+    color: '#1d4ed8',
+  },
+  communicationMetricLabel: {
+    fontSize: 12,
+    color: '#475569',
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+  },
+  communicationSummaryFooter: {
+    fontSize: 12,
+    color: '#4c1d95',
+  },
+  communicationSummaryHighlight: {
+    fontSize: 13,
+    color: '#1e1b4b',
+    fontWeight: '600',
+  },
+  communicationChipRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 8,
+  },
+  communicationChip: {
+    borderRadius: 999,
+    borderWidth: 1,
+    borderColor: '#c7d2fe',
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+    backgroundColor: '#fff',
+  },
+  communicationChipActive: {
+    backgroundColor: '#4338ca',
+    borderColor: '#4338ca',
+  },
+  communicationChipText: {
+    fontWeight: '600',
+    color: '#3730a3',
+  },
+  communicationChipTextActive: {
+    color: '#fff',
+  },
+  communicationMessageField: {
+    marginTop: 4,
+  },
+  communicationAudienceList: {
+    gap: 12,
+  },
+  communicationAudienceCard: {
+    borderWidth: 1,
+    borderColor: '#e0e7ff',
+    borderRadius: 14,
+    padding: 14,
+    backgroundColor: '#fff',
+    gap: 6,
+  },
+  communicationAudienceCardActive: {
+    borderColor: '#4338ca',
+    backgroundColor: '#ede9fe',
+  },
+  communicationAudienceTitle: {
+    fontWeight: '700',
+    color: '#312e81',
+  },
+  communicationAudienceDescription: {
+    fontSize: 12,
+    color: '#475569',
+    lineHeight: 18,
+  },
+  communicationAudienceDescriptionActive: {
+    color: '#312e81',
+  },
+  communicationChannelRow: {
+    flexDirection: 'row',
+    gap: 8,
+  },
+  communicationChannelChip: {
+    borderRadius: 999,
+    borderWidth: 1,
+    borderColor: '#dbeafe',
+    paddingHorizontal: 14,
+    paddingVertical: 8,
+    backgroundColor: '#fff',
+  },
+  communicationChannelChipActive: {
+    backgroundColor: '#1d4ed8',
+    borderColor: '#1d4ed8',
+  },
+  communicationChannelChipText: {
+    color: '#1d4ed8',
+    fontWeight: '600',
+  },
+  communicationChannelChipTextActive: {
+    color: '#fff',
+  },
+  communicationToggleRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    gap: 12,
+  },
+  communicationToggleText: {
+    flex: 1,
+    gap: 4,
+  },
+  communicationTimeline: {
+    marginTop: 16,
+    gap: 12,
+  },
+  timelineHeading: {
+    fontSize: 15,
+    fontWeight: '700',
+    color: '#312e81',
+  },
+  timelineCard: {
+    borderWidth: 1,
+    borderColor: '#ddd6fe',
+    borderRadius: 16,
+    padding: 16,
+    gap: 8,
+    backgroundColor: '#f5f3ff',
+  },
+  timelineTitle: {
+    fontWeight: '700',
+    color: '#312e81',
+    fontSize: 15,
+  },
+  timelineMeta: {
+    fontSize: 12,
+    color: '#4c1d95',
+  },
+  responseRow: {
+    flexDirection: 'row',
+    gap: 12,
+    flexWrap: 'wrap',
+  },
+  responseStat: {
+    fontSize: 12,
+    color: '#1e1b4b',
+    fontWeight: '600',
+  },
+  responseActions: {
+    flexDirection: 'row',
+    gap: 12,
+    flexWrap: 'wrap',
+  },
+  responseActionChip: {
+    backgroundColor: '#ede9fe',
+    borderColor: '#c4b5fd',
   },
   searchInput: {
     flex: 1,

--- a/football-app/src/store/index.ts
+++ b/football-app/src/store/index.ts
@@ -8,6 +8,7 @@ import scheduleReducer from './slices/scheduleSlice';
 import scoutingReducer from './slices/scoutingSlice';
 import tournamentsReducer from './slices/tournamentsSlice';
 import challengesReducer from './slices/challengesSlice';
+import communicationsReducer from './slices/communicationsSlice';
 import { authReducer } from './slices/authSlice';
 import { adminReducer } from './slices/adminSlice';
 
@@ -23,6 +24,7 @@ export const store = configureStore({
     challenges: challengesReducer,
     auth: authReducer,
     admin: adminReducer,
+    communications: communicationsReducer,
 
   },
 });

--- a/football-app/src/store/slices/communicationsSlice.ts
+++ b/football-app/src/store/slices/communicationsSlice.ts
@@ -1,0 +1,274 @@
+import { createSelector, createSlice, nanoid, PayloadAction } from '@reduxjs/toolkit';
+
+import type { RootState } from '..';
+
+export type CommunicationCategory = 'announcement' | 'logistics' | 'lineup' | 'celebration';
+export type CommunicationChannel = 'push' | 'email' | 'sms';
+export type CommunicationAudience = 'everyone' | 'captains' | 'availablePlayers' | 'trialists';
+export type CommunicationStatus = 'draft' | 'scheduled' | 'sent';
+
+export interface CommunicationResponseSummary {
+  confirmed: number;
+  declined: number;
+  awaiting: number;
+}
+
+export interface TeamCommunication {
+  id: string;
+  teamId: string;
+  title: string;
+  body: string;
+  category: CommunicationCategory;
+  audience: CommunicationAudience;
+  channels: CommunicationChannel[];
+  status: CommunicationStatus;
+  createdAt: string;
+  scheduledFor: string | null;
+  followUpReminderMinutes: number | null;
+  requiresResponse: boolean;
+  responseSummary: CommunicationResponseSummary;
+}
+
+interface CommunicationsState {
+  communications: TeamCommunication[];
+}
+
+const initialState: CommunicationsState = {
+  communications: [
+    {
+      id: 'demo-communication-1',
+      teamId: 'demo-team',
+      title: 'Training focus for this week',
+      body: 'Working on high press shape on Tuesday. Reply if you cannot attend.',
+      category: 'announcement',
+      audience: 'everyone',
+      channels: ['push', 'email'],
+      status: 'sent',
+      createdAt: new Date(Date.now() - 1000 * 60 * 60 * 24 * 3).toISOString(),
+      scheduledFor: null,
+      followUpReminderMinutes: 1440,
+      requiresResponse: true,
+      responseSummary: {
+        confirmed: 9,
+        declined: 1,
+        awaiting: 5,
+      },
+    },
+    {
+      id: 'demo-communication-2',
+      teamId: 'demo-team',
+      title: 'Lineup reveal vs Harbour City',
+      body: 'Sharing projected starters and kickoff logistics on Friday evening.',
+      category: 'lineup',
+      audience: 'everyone',
+      channels: ['push'],
+      status: 'scheduled',
+      createdAt: new Date(Date.now() - 1000 * 60 * 60 * 12).toISOString(),
+      scheduledFor: new Date(Date.now() + 1000 * 60 * 60 * 24).toISOString(),
+      followUpReminderMinutes: 120,
+      requiresResponse: false,
+      responseSummary: {
+        confirmed: 0,
+        declined: 0,
+        awaiting: 0,
+      },
+    },
+  ],
+};
+
+type ScheduleCommunicationPayload = {
+  teamId: string;
+  title: string;
+  body: string;
+  category: CommunicationCategory;
+  audience: CommunicationAudience;
+  channels: CommunicationChannel[];
+  scheduledFor?: string | null;
+  followUpReminderMinutes?: number | null;
+  requiresResponse?: boolean;
+  expectedResponders?: number;
+};
+
+type UpdateCommunicationStatusPayload = {
+  id: string;
+  status: CommunicationStatus;
+};
+
+type RecordCommunicationResponsePayload = {
+  id: string;
+  response: 'confirmed' | 'declined';
+};
+
+const communicationsSlice = createSlice({
+  name: 'communications',
+  initialState,
+  reducers: {
+    scheduleCommunication: (state, action: PayloadAction<ScheduleCommunicationPayload>) => {
+      const {
+        teamId,
+        title,
+        body,
+        category,
+        audience,
+        channels,
+        scheduledFor = null,
+        followUpReminderMinutes = null,
+        requiresResponse = false,
+        expectedResponders = 0,
+      } = action.payload;
+
+      const nowIso = new Date().toISOString();
+      const id = nanoid();
+
+      state.communications.unshift({
+        id,
+        teamId,
+        title,
+        body,
+        category,
+        audience,
+        channels,
+        status: scheduledFor ? 'scheduled' : 'sent',
+        createdAt: nowIso,
+        scheduledFor,
+        followUpReminderMinutes,
+        requiresResponse,
+        responseSummary: {
+          confirmed: 0,
+          declined: 0,
+          awaiting: requiresResponse ? Math.max(0, expectedResponders) : 0,
+        },
+      });
+    },
+    updateCommunicationStatus: (
+      state,
+      action: PayloadAction<UpdateCommunicationStatusPayload>,
+    ) => {
+      const { id, status } = action.payload;
+      const communication = state.communications.find((item) => item.id === id);
+
+      if (!communication) {
+        return;
+      }
+
+      communication.status = status;
+      if (status === 'sent') {
+        communication.scheduledFor = null;
+        communication.createdAt = new Date().toISOString();
+      }
+    },
+    recordCommunicationResponse: (
+      state,
+      action: PayloadAction<RecordCommunicationResponsePayload>,
+    ) => {
+      const { id, response } = action.payload;
+      const communication = state.communications.find((item) => item.id === id);
+
+      if (!communication || !communication.requiresResponse) {
+        return;
+      }
+
+      if (response === 'confirmed') {
+        communication.responseSummary.confirmed += 1;
+      } else {
+        communication.responseSummary.declined += 1;
+      }
+
+      if (communication.responseSummary.awaiting > 0) {
+        communication.responseSummary.awaiting -= 1;
+      }
+    },
+  },
+});
+
+export const { scheduleCommunication, updateCommunicationStatus, recordCommunicationResponse } =
+  communicationsSlice.actions;
+
+export default communicationsSlice.reducer;
+
+const selectCommunicationsState = (state: RootState) => state.communications;
+
+const selectCommunicationsList = createSelector(
+  [selectCommunicationsState],
+  (communicationsState) => communicationsState.communications,
+);
+
+export const selectCommunicationsForTeam = createSelector(
+  [selectCommunicationsList, (_state: RootState, teamId?: string | null) => teamId],
+  (communications, teamId) => {
+    if (!teamId) {
+      return [] as TeamCommunication[];
+    }
+
+    return communications
+      .filter((communication) => communication.teamId === teamId)
+      .slice()
+      .sort(
+        (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+      );
+  },
+);
+
+export const selectUpcomingCommunicationsForTeam = createSelector(
+  [selectCommunicationsForTeam],
+  (communications) =>
+    communications
+      .filter((communication) => communication.status === 'scheduled')
+      .slice()
+      .sort((a, b) => {
+        const aTime = a.scheduledFor ? new Date(a.scheduledFor).getTime() : Number.MAX_SAFE_INTEGER;
+        const bTime = b.scheduledFor ? new Date(b.scheduledFor).getTime() : Number.MAX_SAFE_INTEGER;
+        return aTime - bTime;
+      }),
+);
+
+export const selectCommunicationStatsForTeam = createSelector(
+  [selectCommunicationsForTeam],
+  (communications) => {
+    if (communications.length === 0) {
+      return {
+        total: 0,
+        sent: 0,
+        upcoming: 0,
+        reminderCount: 0,
+        averageResponseRate: 0,
+        lastSentAt: null as string | null,
+      };
+    }
+
+    const sent = communications.filter((communication) => communication.status === 'sent');
+    const upcoming = communications.filter((communication) => communication.status === 'scheduled');
+    const reminderCount = communications.filter(
+      (communication) => communication.followUpReminderMinutes && communication.followUpReminderMinutes > 0,
+    ).length;
+
+    const totals = sent.reduce(
+      (accumulator, communication) => {
+        const { confirmed, declined, awaiting } = communication.responseSummary;
+        const total = confirmed + declined + awaiting;
+        const responded = confirmed + declined;
+
+        return {
+          responded: accumulator.responded + responded,
+          total: accumulator.total + total,
+        };
+      },
+      { responded: 0, total: 0 },
+    );
+
+    const averageResponseRate = totals.total > 0 ? Math.round((totals.responded / totals.total) * 100) : 0;
+
+    const lastSent = sent
+      .slice()
+      .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())[0];
+
+    return {
+      total: communications.length,
+      sent: sent.length,
+      upcoming: upcoming.length,
+      reminderCount,
+      averageResponseRate,
+      lastSentAt: lastSent ? lastSent.createdAt : null,
+    };
+  },
+);


### PR DESCRIPTION
## Summary
- add a communications slice with scheduling, status, and engagement selectors
- extend Manage Team with planning UI, reminders, channel targeting, and response tracking
- surface latest communications on the team screen and team cards for quick visibility

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e5b0ec55c0832e93ed97ff13eceaf6