### PR TITLE
Add bottom tab navigation for authenticated users

### DIFF
--- a/football-app/package.json
+++ b/football-app/package.json
@@ -28,6 +28,7 @@
   "devDependencies": {},
   "vendoredDependencies": {
     "@react-native-async-storage/async-storage": "^1.23.1",
+    "@react-navigation/bottom-tabs": "^7.1.2",
     "@react-navigation/native": "^7.1.17",
     "@react-navigation/native-stack": "^7.3.25",
     "@reduxjs/toolkit": "^2.8.2",
@@ -52,6 +53,7 @@
   },
   "localDependencies": [
     "@react-native-async-storage/async-storage",
+    "@react-navigation/bottom-tabs",
     "@react-navigation/native",
     "@react-navigation/native-stack",
     "@reduxjs/toolkit",

--- a/football-app/src/App.tsx
+++ b/football-app/src/App.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef } from 'react';
 import { NavigationContainer } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import { Provider } from 'react-redux';
 import { AppRegistry, Platform, ActivityIndicator, View, Text, StyleSheet } from 'react-native';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
@@ -11,11 +12,12 @@ import CreateTeamScreen from './screens/CreateTeamScreen';
 import ManageTeamScreen from './screens/ManageTeamScreen';
 import TournamentScreen from './screens/TournamentScreen';
 import ProfileScreen from './screens/ProfileScreen';
+import CreateMatchScreen from './screens/CreateMatchScreen';
 import LoginScreen from './screens/LoginScreen';
 import RegisterScreen from './screens/RegisterScreen';
 import AdminDashboardScreen from './screens/AdminDashboardScreen';
 import { store } from './store';
-import { RootStackParamList } from './types/navigation';
+import { AuthenticatedTabParamList, RootStackParamList } from './types/navigation';
 import { useAppDispatch, useAppSelector } from './store/hooks';
 import { hydratePremium } from './store/slices/premiumSlice';
 import { loadPremiumEntitlement } from './services/premiumStorage';
@@ -25,6 +27,29 @@ import { hydrateTeams } from './store/slices/teamsSlice';
 import { loadStoredTeams, persistTeams as persistTeamsToStorage } from './services/teamStorage';
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
+const Tab = createBottomTabNavigator<AuthenticatedTabParamList>();
+
+const AuthenticatedTabs = () => (
+  <Tab.Navigator screenOptions={{ headerShown: false }}>
+    <Tab.Screen name="Dashboard" component={HomeScreen} options={{ tabBarLabel: 'Dashboard' }} />
+    <Tab.Screen
+      name="ManageTeams"
+      component={TeamScreen}
+      options={{ title: 'Manage Teams', tabBarLabel: 'Manage Teams' }}
+    />
+    <Tab.Screen
+      name="CreateMatch"
+      component={CreateMatchScreen}
+      options={{ title: 'Create a Match', tabBarLabel: 'Create a Match' }}
+    />
+    <Tab.Screen
+      name="Tournaments"
+      component={TournamentScreen}
+      options={{ tabBarLabel: 'Tournaments' }}
+    />
+    <Tab.Screen name="Profile" component={ProfileScreen} options={{ tabBarLabel: 'Profile' }} />
+  </Tab.Navigator>
+);
 
 const PremiumBootstrapper = () => {
   const dispatch = useAppDispatch();
@@ -125,12 +150,13 @@ const RootNavigator = () => {
     <Stack.Navigator>
       {currentUser ? (
         <>
-          <Stack.Screen name="Home" component={HomeScreen} />
-          <Stack.Screen name="Team" component={TeamScreen} />
+          <Stack.Screen name="MainTabs" component={AuthenticatedTabs} options={{ headerShown: false }} />
           <Stack.Screen name="CreateTeam" component={CreateTeamScreen} />
-          <Stack.Screen name="ManageTeam" component={ManageTeamScreen} options={{ title: 'Manage Team' }} />
-          <Stack.Screen name="Tournaments" component={TournamentScreen} />
-          <Stack.Screen name="Profile" component={ProfileScreen} />
+          <Stack.Screen
+            name="ManageTeam"
+            component={ManageTeamScreen}
+            options={{ title: 'Manage Team' }}
+          />
           {currentUser.role === 'admin' && (
             <Stack.Screen
               name="AdminDashboard"

--- a/football-app/src/screens/AdminDashboardScreen.tsx
+++ b/football-app/src/screens/AdminDashboardScreen.tsx
@@ -214,7 +214,10 @@ const AdminDashboardScreen: React.FC<AdminDashboardScreenProps> = ({ navigation 
           <Text style={styles.unauthorisedText}>
             You need an admin account to view the management centre.
           </Text>
-          <TouchableOpacity style={styles.backButton} onPress={() => navigation.navigate('Home')}>
+          <TouchableOpacity
+            style={styles.backButton}
+            onPress={() => navigation.navigate('MainTabs', { screen: 'Dashboard' })}
+          >
             <Text style={styles.backButtonText}>Go back</Text>
           </TouchableOpacity>
         </View>

--- a/football-app/src/screens/CreateMatchScreen.tsx
+++ b/football-app/src/screens/CreateMatchScreen.tsx
@@ -1,0 +1,170 @@
+import React from 'react';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import {
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import type { BottomTabNavigationProp } from '@react-navigation/bottom-tabs';
+import type { CompositeNavigationProp } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
+
+import { useAppSelector } from '../store/hooks';
+import type { AuthenticatedTabParamList, RootStackParamList } from '../types/navigation';
+
+type CreateMatchNavigationProp = CompositeNavigationProp<
+  BottomTabNavigationProp<AuthenticatedTabParamList, 'CreateMatch'>,
+  NativeStackNavigationProp<RootStackParamList>
+>;
+
+const CreateMatchScreen: React.FC = () => {
+  const navigation = useNavigation<CreateMatchNavigationProp>();
+  const teams = useAppSelector((state) => state.teams.teams);
+
+  return (
+    <SafeAreaView style={styles.safeArea}>
+      <ScrollView contentContainerStyle={styles.content}>
+        <Text style={styles.title}>Organise a new match</Text>
+        <Text style={styles.subtitle}>
+          Choose one of your teams to start proposing fixtures, manage kickoff voting and sync
+          confirmed matches to your calendar.
+        </Text>
+
+        {teams.length === 0 ? (
+          <View style={styles.emptyState}>
+            <Text style={styles.emptyStateHeading}>No teams yet</Text>
+            <Text style={styles.emptyStateBody}>
+              Create a team first so you can invite players and set up your first matchday.
+            </Text>
+            <TouchableOpacity
+              accessibilityRole="button"
+              onPress={() => navigation.navigate('CreateTeam')}
+              style={styles.primaryButton}
+            >
+              <Text style={styles.primaryButtonText}>Create a team</Text>
+            </TouchableOpacity>
+          </View>
+        ) : (
+          <View style={styles.teamList}>
+            <Text style={styles.teamListHeading}>Select a team</Text>
+            {teams.map((team) => {
+              const playerLabel = team.members.length === 1 ? 'player' : 'players';
+
+              return (
+                <TouchableOpacity
+                  key={team.id}
+                  accessibilityRole="button"
+                  onPress={() => navigation.navigate('ManageTeam', { teamId: team.id })}
+                  style={styles.teamCard}
+                >
+                  <Text style={styles.teamName}>{team.name}</Text>
+                  <Text style={styles.teamMeta}>
+                    {team.members.length} {playerLabel}
+                  </Text>
+                  <Text style={styles.teamCta}>Manage fixtures</Text>
+                </TouchableOpacity>
+              );
+            })}
+          </View>
+        )}
+      </ScrollView>
+    </SafeAreaView>
+  );
+};
+
+const styles = StyleSheet.create({
+  safeArea: {
+    flex: 1,
+    backgroundColor: '#f9fafb',
+  },
+  content: {
+    padding: 24,
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: '700',
+    marginBottom: 12,
+    color: '#111827',
+  },
+  subtitle: {
+    fontSize: 16,
+    color: '#4b5563',
+    lineHeight: 22,
+    marginBottom: 24,
+  },
+  emptyState: {
+    backgroundColor: '#fff',
+    borderRadius: 16,
+    padding: 24,
+    shadowColor: '#111827',
+    shadowOpacity: 0.08,
+    shadowOffset: { width: 0, height: 4 },
+    shadowRadius: 12,
+    elevation: 3,
+  },
+  emptyStateHeading: {
+    fontSize: 20,
+    fontWeight: '600',
+    marginBottom: 8,
+    color: '#111827',
+  },
+  emptyStateBody: {
+    fontSize: 16,
+    color: '#4b5563',
+    marginBottom: 16,
+    lineHeight: 22,
+  },
+  primaryButton: {
+    backgroundColor: '#2563eb',
+    borderRadius: 12,
+    paddingVertical: 14,
+    alignItems: 'center',
+  },
+  primaryButtonText: {
+    color: '#fff',
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  teamList: {
+    marginTop: 8,
+    width: '100%',
+  },
+  teamListHeading: {
+    fontSize: 18,
+    fontWeight: '600',
+    color: '#111827',
+    marginBottom: 8,
+  },
+  teamCard: {
+    backgroundColor: '#fff',
+    borderRadius: 16,
+    padding: 20,
+    shadowColor: '#111827',
+    shadowOpacity: 0.08,
+    shadowOffset: { width: 0, height: 4 },
+    shadowRadius: 12,
+    elevation: 2,
+    marginBottom: 16,
+  },
+  teamName: {
+    fontSize: 18,
+    fontWeight: '600',
+    color: '#111827',
+  },
+  teamMeta: {
+    fontSize: 14,
+    color: '#6b7280',
+    marginTop: 4,
+  },
+  teamCta: {
+    marginTop: 12,
+    fontSize: 14,
+    fontWeight: '600',
+    color: '#2563eb',
+  },
+});
+
+export default CreateMatchScreen;

--- a/football-app/src/screens/CreateTeamScreen.tsx
+++ b/football-app/src/screens/CreateTeamScreen.tsx
@@ -65,7 +65,7 @@ const CreateTeamScreen: React.FC = () => {
     setName('');
     setMembersText('');
 
-    navigation.navigate('Team');
+    navigation.navigate('MainTabs', { screen: 'ManageTeams' });
     Alert.alert('Team created', `${teamName} has been added to your teams.`);
   };
 

--- a/football-app/src/screens/HomeScreen.tsx
+++ b/football-app/src/screens/HomeScreen.tsx
@@ -2,10 +2,12 @@ import React from 'react';
 import { Alert, StyleSheet, View, Text, Button, TouchableOpacity } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { BottomTabNavigationProp } from '@react-navigation/bottom-tabs';
+import { CompositeNavigationProp } from '@react-navigation/native';
 
 import BannerAdSlot from '../components/BannerAdSlot';
 import { defaultBannerSize, homeBannerAdUnitId } from '../config/ads';
-import { RootStackParamList } from '../types/navigation';
+import { AuthenticatedTabParamList, RootStackParamList } from '../types/navigation';
 import { useAppDispatch, useAppSelector } from '../store/hooks';
 import { selectCurrentUser } from '../store/slices/authSlice';
 import {
@@ -15,7 +17,10 @@ import {
 } from '../store/slices/challengesSlice';
 import { creditWallet } from '../store/slices/walletSlice';
 
-type HomeScreenNavigationProp = NativeStackNavigationProp<RootStackParamList, 'Home'>;
+type HomeScreenNavigationProp = CompositeNavigationProp<
+  BottomTabNavigationProp<AuthenticatedTabParamList, 'Dashboard'>,
+  NativeStackNavigationProp<RootStackParamList>
+>;
 
 interface HomeScreenProps {
   navigation: HomeScreenNavigationProp;
@@ -57,7 +62,7 @@ const HomeScreen: React.FC<HomeScreenProps> = ({ navigation }) => {
         <Text style={styles.subtitle}>{welcomeMessage}</Text>
         <View style={styles.buttonGroup}>
           <View style={styles.buttonWrapper}>
-            <Button title="Manage Teams" onPress={() => navigation.navigate('Team')} />
+            <Button title="Manage Teams" onPress={() => navigation.navigate('ManageTeams')} />
           </View>
           <View style={styles.buttonWrapper}>
             <Button title="Create a Team" onPress={() => navigation.navigate('CreateTeam')} />

--- a/football-app/src/screens/ProfileScreen.tsx
+++ b/football-app/src/screens/ProfileScreen.tsx
@@ -16,6 +16,8 @@ import {
   DatePickerIOS,
 } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
+import type { BottomTabNavigationProp } from '@react-navigation/bottom-tabs';
+import type { CompositeNavigationProp } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import type { Product, ProductPurchase, PurchaseError } from 'react-native-iap';
 
@@ -65,7 +67,7 @@ import {
   updateBiometricPreference,
   updateMarketingPreference,
 } from '../store/slices/authSlice';
-import type { RootStackParamList } from '../types/navigation';
+import type { AuthenticatedTabParamList, RootStackParamList } from '../types/navigation';
 import { detectBiometricSupport, requestBiometricAuthentication } from '../services/biometricAuth';
 import type { BiometricSupport } from '../services/biometricAuth';
 import { generateTrainingPlans } from '../services/trainingPlans';
@@ -132,8 +134,13 @@ const defaultDob = () => {
   return new Date(today.getFullYear() - 18, today.getMonth(), today.getDate());
 };
 
+type ProfileScreenNavigationProp = CompositeNavigationProp<
+  BottomTabNavigationProp<AuthenticatedTabParamList, 'Profile'>,
+  NativeStackNavigationProp<RootStackParamList>
+>;
+
 const ProfileScreen: React.FC = () => {
-  const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
+  const navigation = useNavigation<ProfileScreenNavigationProp>();
   const dispatch = useAppDispatch();
   const credits = useAppSelector((state) => state.wallet.credits);
   const premium = useAppSelector((state) => state.premium);

--- a/football-app/src/screens/TeamScreen.tsx
+++ b/football-app/src/screens/TeamScreen.tsx
@@ -2,14 +2,15 @@ import React, { useMemo } from 'react';
 import { StyleSheet, View, Text, FlatList, Button } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
-import { useNavigation } from '@react-navigation/native';
+import { BottomTabNavigationProp } from '@react-navigation/bottom-tabs';
+import { CompositeNavigationProp, useNavigation } from '@react-navigation/native';
 
 import TeamCard from '../components/TeamCard';
 import BannerAdSlot from '../components/BannerAdSlot';
 import { defaultBannerSize, teamBannerAdUnitId } from '../config/ads';
 import { useAppDispatch, useAppSelector } from '../store/hooks';
 import { removeTeam, Team } from '../store/slices/teamsSlice';
-import { RootStackParamList } from '../types/navigation';
+import { AuthenticatedTabParamList, RootStackParamList } from '../types/navigation';
 import {
   formatKickoffTime,
   getFixtureStartDate,
@@ -18,7 +19,10 @@ import {
   selectTeamRecord,
 } from '../store/slices/scheduleSlice';
 
-type TeamScreenNavigationProp = NativeStackNavigationProp<RootStackParamList, 'Team'>;
+type TeamScreenNavigationProp = CompositeNavigationProp<
+  BottomTabNavigationProp<AuthenticatedTabParamList, 'ManageTeams'>,
+  NativeStackNavigationProp<RootStackParamList>
+>;
 
 
 const TeamScreen: React.FC = () => {

--- a/football-app/src/types/navigation.ts
+++ b/football-app/src/types/navigation.ts
@@ -1,11 +1,18 @@
+import type { NavigatorScreenParams } from '@react-navigation/native';
+
+export type AuthenticatedTabParamList = {
+  Dashboard: undefined;
+  ManageTeams: undefined;
+  CreateMatch: undefined;
+  Tournaments: undefined;
+  Profile: undefined;
+};
+
 export type RootStackParamList = {
   Login: undefined;
   Register: undefined;
-  Home: undefined;
-  Team: undefined;
+  MainTabs: NavigatorScreenParams<AuthenticatedTabParamList>;
   CreateTeam: undefined;
   ManageTeam: { teamId: string };
-  Tournaments: undefined;
-  Profile: undefined;
   AdminDashboard: undefined;
 };


### PR DESCRIPTION
## Summary
- replace the authenticated stack with a bottom tab navigator that surfaces dashboard, team management, match creation, tournaments, and profile views
- add a dedicated Create Match screen that guides users to manage fixtures for specific teams
- update supporting navigation types and flows to ensure stack routes navigate correctly into the tab structure

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e5b2b08b2c832ebedaa2b89f8ea3f1