### PR TITLE
Add persistent navigation and refresh authenticated screens

### DIFF
--- a/docs/team-communication-strategy.md
+++ b/docs/team-communication-strategy.md
@@ -1,0 +1,50 @@
+# Team Communication Strategy
+
+## Current Product Understanding
+- **Home experience** welcomes users, personalizes the greeting for signed-in members, and routes into the major areas of the app while surfacing a banner ad placement.
+- **Team management** pulls roster data from Redux, allows members to remove or manage teams, and highlights premium-only analytics when the user lacks entitlement.
+- **Tournament participation** hinges on rewarded ads that top up wallet credits and unlock premium insights once the user has sufficient access.
+- **Profile hub** collects detailed personal data, marketing preferences, wallet packages, and premium purchase flows, persisting everything locally when the capability exists.
+
+These areas form the backbone for the feature work already in flight—match scheduling, scouting marketplace, seasonal ladders, community challenges, and contextual training guidance.
+
+## Recommendation: Layered Team Communication
+A dedicated chat surface can complement the in-progress features, but it should be scoped to match the workflows captains already manage inside the app. Rather than launching a generic messenger, consider a layered approach:
+
+1. **Matchday Threads**
+   - Auto-create threads for each scheduled fixture so coaches can confirm availability, share lineups, and pin logistics.
+   - Attach match metadata (opponent, venue, kickoff time) directly from the scheduling module so conversations stay contextual.
+
+2. **Team Announcement Channel**
+   - Provide a one-to-many broadcast space where coaches or admins can push urgent updates (training cancellations, arrival reminders).
+   - Allow reactions or quick acknowledgement buttons to gauge team readiness without cluttering the thread.
+
+3. **Direct Messages and Small Groups (Phase 2)**
+   - After validating engagement, extend messaging to player-to-player or staff subgroups for tactical discussions.
+   - Gate advanced capabilities (large media uploads, unlimited message history) behind premium to reinforce the existing entitlement model.
+
+### Implementation Considerations
+- **Push notifications & reminders:** Use the existing notification infrastructure to surface unread messages and matchday alerts.
+- **Moderation & safety:** Offer basic moderation controls (delete, mute, report) before opening broader chats, especially if youth teams participate.
+- **Offline support:** Cache recent messages locally to ensure captains can review logistics even without a stable connection.
+- **Ad & premium strategy:** Sponsored tips or premium-only tactical libraries can be embedded in match threads, aligning with the monetization pattern already present in tournaments and the profile wallet.
+
+## Alternatives & Complements
+If a full chat rollout feels heavy, explore lighter-weight communication features first:
+- **Availability Polls:** Let captains request simple yes/no/maybe responses for training or match attendance, feeding the scheduling module.
+- **Automated Summaries:** Generate post-match recaps (result, player of the match, wallet credit changes) and publish them to a shared feed.
+- **Integrations:** Provide quick-share to WhatsApp/Telegram for teams that already coordinate externally, while capturing feedback to iterate on native chat.
+
+Starting with contextual messaging tied to scheduling delivers the highest immediate value and creates a natural upgrade path toward richer, premium-ready communication tools.
+
+## Recent Product Improvements
+- **Persistent navigation shell:** Added a universal bottom navigation bar so logged-in members can jump between Home, Teams, Tournaments, Profile, and (when applicable) Admin at any time without losing context.
+- **Home experience refresh:** Restructured the dashboard with scrollable quick actions, richer feature highlights, and surfaced design opportunities inspired by the latest feature roll-out.
+- **Screen scaffolding:** Updated team, tournament, profile, and admin management areas to share a consistent layout that leaves room for future contextual messaging panels or scheduling widgets.
+
+## Additional Feature & Design Opportunities
+- **Clubhouse timeline:** Give each team a shareable feed of match reports, training notes, and scouting updates. Pair timeline posts with inline reactions to keep engagement high without requiring full chat replies.
+- **Broadcast studio:** Layer a lightweight live commentary mode on top of match scheduling so analysts can post real-time updates for remote supporters. Replay highlights could be saved as stories inside the Home experience.
+- **Kit designer and badge vault:** Offer customisable kits and crest templates with colour pickers, unlockable via premium or tournament wins, to reinforce club identity across the app.
+- **Match insights storyboard:** Visualise squad momentum, fatigue, and opponent tendencies with card-based storytelling. These could animate subtly when new analytics arrive after a recorded match.
+- **Immersive theming:** Introduce alternate themes (e.g., “Stadium Lights” dark mode, “Academy Daylight” pastel mode) and allow team captains to assign team-specific accent colours that propagate to cards, charts, and the persistent navigation bar.

--- a/football-app/src/components/AuthenticatedScreenContainer.tsx
+++ b/football-app/src/components/AuthenticatedScreenContainer.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { StyleProp, StyleSheet, View, ViewStyle } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+
+import PersistentNavigation, { NAVIGATION_HEIGHT } from './PersistentNavigation';
+
+interface AuthenticatedScreenContainerProps {
+  children: React.ReactNode;
+  style?: StyleProp<ViewStyle>;
+  contentStyle?: StyleProp<ViewStyle>;
+}
+
+const AuthenticatedScreenContainer: React.FC<AuthenticatedScreenContainerProps> = ({
+  children,
+  style,
+  contentStyle,
+}) => {
+  return (
+    <SafeAreaView style={[styles.safeArea, style]}>
+      <View style={[styles.content, contentStyle]}>{children}</View>
+      <PersistentNavigation />
+    </SafeAreaView>
+  );
+};
+
+const styles = StyleSheet.create({
+  safeArea: {
+    flex: 1,
+    backgroundColor: '#f3f4f6',
+  },
+  content: {
+    flex: 1,
+    paddingBottom: NAVIGATION_HEIGHT + 16,
+  },
+});
+
+export default AuthenticatedScreenContainer;

--- a/football-app/src/components/PersistentNavigation.tsx
+++ b/football-app/src/components/PersistentNavigation.tsx
@@ -1,0 +1,126 @@
+import React, { useMemo } from 'react';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { useNavigation, useRoute } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
+
+import { useAppSelector } from '../store/hooks';
+import { selectCurrentUser } from '../store/slices/authSlice';
+import type { RootStackParamList } from '../types/navigation';
+
+export const NAVIGATION_HEIGHT = 72;
+
+type NavKey = 'Home' | 'Team' | 'Tournaments' | 'Profile' | 'AdminDashboard';
+
+interface NavItem {
+  key: NavKey;
+  label: string;
+  route: keyof RootStackParamList;
+  description: string;
+}
+
+const ROUTE_TO_KEY: Partial<Record<keyof RootStackParamList, NavKey>> = {
+  Home: 'Home',
+  Team: 'Team',
+  CreateTeam: 'Team',
+  ManageTeam: 'Team',
+  Tournaments: 'Tournaments',
+  Profile: 'Profile',
+  AdminDashboard: 'AdminDashboard',
+};
+
+const PersistentNavigation: React.FC = () => {
+  const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
+  const route = useRoute();
+  const currentUser = useAppSelector(selectCurrentUser);
+
+  const navItems = useMemo<NavItem[]>(() => {
+    const baseItems: NavItem[] = [
+      { key: 'Home', label: 'Home', route: 'Home', description: 'Overview' },
+      { key: 'Team', label: 'Teams', route: 'Team', description: 'Manage squads' },
+      { key: 'Tournaments', label: 'Tournaments', route: 'Tournaments', description: 'Compete' },
+      { key: 'Profile', label: 'Profile', route: 'Profile', description: 'Account' },
+    ];
+
+    if (currentUser?.role === 'admin') {
+      baseItems.splice(3, 0, {
+        key: 'AdminDashboard',
+        label: 'Admin',
+        route: 'AdminDashboard',
+        description: 'Operations',
+      });
+    }
+
+    return baseItems;
+  }, [currentUser?.role]);
+
+  const activeKey = ROUTE_TO_KEY[route.name as keyof RootStackParamList] ?? 'Home';
+
+  return (
+    <View style={styles.container}>
+      {navItems.map((item) => {
+        const isActive = item.key === activeKey;
+
+        return (
+          <TouchableOpacity
+            key={item.key}
+            accessibilityRole="button"
+            accessibilityState={{ selected: isActive }}
+            onPress={() => navigation.navigate(item.route)}
+            style={[styles.navButton, isActive && styles.navButtonActive]}
+          >
+            <Text style={[styles.navLabel, isActive && styles.navLabelActive]}>{item.label}</Text>
+            <Text style={[styles.navDescription, isActive && styles.navDescriptionActive]}>
+              {item.description}
+            </Text>
+          </TouchableOpacity>
+        );
+      })}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    height: NAVIGATION_HEIGHT,
+    backgroundColor: '#ffffff',
+    borderTopWidth: 1,
+    borderColor: '#e5e7eb',
+    flexDirection: 'row',
+    alignItems: 'stretch',
+    justifyContent: 'space-between',
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    gap: 12,
+  },
+  navButton: {
+    flex: 1,
+    borderRadius: 14,
+    backgroundColor: '#f8fafc',
+    borderWidth: 1,
+    borderColor: '#e2e8f0',
+    justifyContent: 'center',
+    alignItems: 'center',
+    paddingVertical: 6,
+  },
+  navButtonActive: {
+    backgroundColor: '#1d4ed8',
+    borderColor: '#1d4ed8',
+  },
+  navLabel: {
+    fontSize: 14,
+    fontWeight: '700',
+    color: '#1f2937',
+  },
+  navLabelActive: {
+    color: '#ffffff',
+  },
+  navDescription: {
+    fontSize: 11,
+    color: '#64748b',
+  },
+  navDescriptionActive: {
+    color: '#bfdbfe',
+  },
+});
+
+export default PersistentNavigation;

--- a/football-app/src/screens/AdminDashboardScreen.tsx
+++ b/football-app/src/screens/AdminDashboardScreen.tsx
@@ -10,7 +10,6 @@ import {
   View,
 } from 'react-native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
-import { SafeAreaView } from 'react-native-safe-area-context';
 
 import { RootStackParamList } from '../types/navigation';
 import { useAppDispatch, useAppSelector } from '../store/hooks';
@@ -32,6 +31,7 @@ import {
   updatePaymentStatus,
 } from '../store/slices/adminSlice';
 import type { MarketingAudience, PaymentStatus } from '../types/admin';
+import AuthenticatedScreenContainer from '../components/AuthenticatedScreenContainer';
 
 interface AdminDashboardScreenProps {
   navigation: NativeStackNavigationProp<RootStackParamList, 'AdminDashboard'>;
@@ -208,7 +208,7 @@ const AdminDashboardScreen: React.FC<AdminDashboardScreenProps> = ({ navigation 
 
   if (!currentUser || currentUser.role !== 'admin') {
     return (
-      <SafeAreaView style={styles.safeArea}>
+      <AuthenticatedScreenContainer style={styles.safeArea} contentStyle={styles.centerContent}>
         <View style={styles.unauthorisedContainer}>
           <Text style={styles.unauthorisedTitle}>Access restricted</Text>
           <Text style={styles.unauthorisedText}>
@@ -218,23 +218,23 @@ const AdminDashboardScreen: React.FC<AdminDashboardScreenProps> = ({ navigation 
             <Text style={styles.backButtonText}>Go back</Text>
           </TouchableOpacity>
         </View>
-      </SafeAreaView>
+      </AuthenticatedScreenContainer>
     );
   }
 
   if (!adminInitialized || adminLoading) {
     return (
-      <SafeAreaView style={styles.safeArea}>
+      <AuthenticatedScreenContainer style={styles.safeArea} contentStyle={styles.centerContent}>
         <View style={styles.loadingContainer}>
           <ActivityIndicator size="large" color="#2563eb" />
           <Text style={styles.loadingText}>Loading admin data…</Text>
         </View>
-      </SafeAreaView>
+      </AuthenticatedScreenContainer>
     );
   }
 
   return (
-    <SafeAreaView style={styles.safeArea}>
+    <AuthenticatedScreenContainer style={styles.safeArea}>
       <ScrollView contentContainerStyle={styles.scrollContent}>
         <Text style={styles.screenTitle}>Admin centre</Text>
         <Text style={styles.screenSubtitle}>
@@ -568,7 +568,7 @@ const AdminDashboardScreen: React.FC<AdminDashboardScreenProps> = ({ navigation 
           ))}
         </View>
       </ScrollView>
-    </SafeAreaView>
+    </AuthenticatedScreenContainer>
   );
 };
 
@@ -576,6 +576,12 @@ const styles = StyleSheet.create({
   safeArea: {
     flex: 1,
     backgroundColor: '#f1f5f9',
+  },
+  centerContent: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: 24,
   },
   scrollContent: {
     padding: 24,
@@ -786,9 +792,8 @@ const styles = StyleSheet.create({
     color: '#f8fafc',
   },
   loadingContainer: {
-    flex: 1,
-    justifyContent: 'center',
     alignItems: 'center',
+    gap: 12,
   },
   loadingText: {
     marginTop: 16,
@@ -799,10 +804,8 @@ const styles = StyleSheet.create({
     marginBottom: 16,
   },
   unauthorisedContainer: {
-    flex: 1,
-    justifyContent: 'center',
     alignItems: 'center',
-    padding: 24,
+    gap: 16,
   },
   unauthorisedTitle: {
     fontSize: 24,

--- a/football-app/src/screens/CreateTeamScreen.tsx
+++ b/football-app/src/screens/CreateTeamScreen.tsx
@@ -1,9 +1,9 @@
 import React, { useMemo, useState } from 'react';
-import { SafeAreaView } from 'react-native-safe-area-context';
 import { Alert, Button, StyleSheet, Text, TextInput, View } from 'react-native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { useNavigation } from '@react-navigation/native';
 
+import AuthenticatedScreenContainer from '../components/AuthenticatedScreenContainer';
 import { RootStackParamList } from '../types/navigation';
 import { useAppDispatch } from '../store/hooks';
 import { TeamMember, TeamRole, addTeam, defaultTeamSettings } from '../store/slices/teamsSlice';
@@ -70,38 +70,36 @@ const CreateTeamScreen: React.FC = () => {
   };
 
   return (
-    <SafeAreaView style={styles.safeArea}>
-      <View style={styles.content}>
-        <Text style={styles.title}>Create a Team</Text>
-        <Text style={styles.description}>
-          Add your team name and an optional comma-separated list of members.
-        </Text>
+    <AuthenticatedScreenContainer style={styles.safeArea} contentStyle={styles.content}>
+      <Text style={styles.title}>Create a Team</Text>
+      <Text style={styles.description}>
+        Add your team name and an optional comma-separated list of members.
+      </Text>
 
-        <View style={styles.formField}>
-          <Text style={styles.label}>Team name</Text>
-          <TextInput
-            value={name}
-            onChangeText={setName}
-            placeholder="e.g. Thunderbolts"
-            style={styles.input}
-            autoCapitalize="words"
-          />
-        </View>
-
-        <View style={styles.formField}>
-          <Text style={styles.label}>Members</Text>
-          <TextInput
-            value={membersText}
-            onChangeText={setMembersText}
-            placeholder="Add members separated by commas"
-            style={[styles.input, styles.multilineInput]}
-            multiline
-          />
-        </View>
-
-        <Button title="Save team" onPress={handleSubmit} />
+      <View style={styles.formField}>
+        <Text style={styles.label}>Team name</Text>
+        <TextInput
+          value={name}
+          onChangeText={setName}
+          placeholder="e.g. Thunderbolts"
+          style={styles.input}
+          autoCapitalize="words"
+        />
       </View>
-    </SafeAreaView>
+
+      <View style={styles.formField}>
+        <Text style={styles.label}>Members</Text>
+        <TextInput
+          value={membersText}
+          onChangeText={setMembersText}
+          placeholder="Add members separated by commas"
+          style={[styles.input, styles.multilineInput]}
+          multiline
+        />
+      </View>
+
+      <Button title="Save team" onPress={handleSubmit} />
+    </AuthenticatedScreenContainer>
   );
 };
 
@@ -111,8 +109,8 @@ const styles = StyleSheet.create({
     backgroundColor: '#fff',
   },
   content: {
-    flex: 1,
     padding: 24,
+    gap: 16,
   },
   title: {
     fontSize: 24,

--- a/football-app/src/screens/HomeScreen.tsx
+++ b/football-app/src/screens/HomeScreen.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import { StyleSheet, View, Text, Button } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
+import { StyleSheet, View, Text, ScrollView, TouchableOpacity } from 'react-native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 
+import AuthenticatedScreenContainer from '../components/AuthenticatedScreenContainer';
 import BannerAdSlot from '../components/BannerAdSlot';
 import { defaultBannerSize, homeBannerAdUnitId } from '../config/ads';
 import { RootStackParamList } from '../types/navigation';
@@ -15,6 +15,43 @@ interface HomeScreenProps {
   navigation: HomeScreenNavigationProp;
 }
 
+const quickActions = [
+  { label: 'Manage teams', description: 'Edit rosters & tactics', route: 'Team' as const },
+  { label: 'Create team', description: 'Spin up a new squad', route: 'CreateTeam' as const },
+  { label: 'Join tournaments', description: 'Enter upcoming events', route: 'Tournaments' as const },
+  { label: 'Update profile', description: 'Refresh details & premium', route: 'Profile' as const },
+];
+
+const featureHighlights = [
+  {
+    title: 'Match scheduling hub',
+    copy:
+      'Coordinate fixtures, collect availability votes, and sync confirmed games straight to everyone’s calendars.',
+  },
+  {
+    title: 'Scouting marketplace',
+    copy:
+      'Promote open positions, browse free agents by skill tags, and invite prospects to trial sessions.',
+  },
+  {
+    title: 'Season ladders & challenges',
+    copy:
+      'Track promotion and relegation paths, tackle rotating community skill drills, and earn badge rewards.',
+  },
+  {
+    title: 'Personalised training packs',
+    copy:
+      'Serve drills and wellness tips tuned to each player’s profile, with premium plans unlocking deeper insights.',
+  },
+];
+
+const designOpportunities = [
+  'Introduce a matchday dashboard tile that surfaces live tactics, kit colours, and weather in a single glance.',
+  'Layer subtle gradients and club accent colours into team cards for clearer visual hierarchy.',
+  'Add micro-interactions (progress pulses, celebratory confetti) when teams hit milestones or unlock rewards.',
+  'Bring in a dark mode palette that echoes stadium floodlights for late-night strategising.',
+];
+
 const HomeScreen: React.FC<HomeScreenProps> = ({ navigation }) => {
   const currentUser = useAppSelector(selectCurrentUser);
   const greetingName = currentUser?.fullName.split(' ')[0] ?? 'coach';
@@ -23,59 +60,173 @@ const HomeScreen: React.FC<HomeScreenProps> = ({ navigation }) => {
     : 'Sign in to unlock the full football experience.';
 
   return (
-    <SafeAreaView style={styles.safeArea}>
-      <View style={styles.content}>
-        <Text style={styles.title}>Welcome to the Football App!</Text>
-        <Text style={styles.subtitle}>{welcomeMessage}</Text>
-        <View style={styles.buttonGroup}>
-          <View style={styles.buttonWrapper}>
-            <Button title="Manage Teams" onPress={() => navigation.navigate('Team')} />
-          </View>
-          <View style={styles.buttonWrapper}>
-            <Button title="Create a Team" onPress={() => navigation.navigate('CreateTeam')} />
-          </View>
-          <View style={styles.buttonWrapper}>
-            <Button title="Join Tournaments" onPress={() => navigation.navigate('Tournaments')} />
-          </View>
-          <View style={styles.buttonWrapper}>
-            <Button title="Profile" onPress={() => navigation.navigate('Profile')} />
-          </View>
-
+    <AuthenticatedScreenContainer contentStyle={styles.container}>
+      <ScrollView
+        contentContainerStyle={styles.scrollContent}
+        showsVerticalScrollIndicator={false}
+        bounces
+      >
+        <View style={styles.heroCard}>
+          <Text style={styles.eyebrow}>Welcome to Football App</Text>
+          <Text style={styles.title}>{welcomeMessage}</Text>
+          <Text style={styles.helperText}>
+            Manage squads, schedule fixtures, and unlock insights that keep your club one step ahead.
+          </Text>
         </View>
-      </View>
-      <BannerAdSlot unitId={homeBannerAdUnitId} size={defaultBannerSize} />
-    </SafeAreaView>
+
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>Quick actions</Text>
+          <View style={styles.quickActionGrid}>
+            {quickActions.map((action) => (
+              <TouchableOpacity
+                key={action.route}
+                onPress={() => navigation.navigate(action.route)}
+                style={styles.quickActionCard}
+              >
+                <Text style={styles.quickActionLabel}>{action.label}</Text>
+                <Text style={styles.quickActionDescription}>{action.description}</Text>
+              </TouchableOpacity>
+            ))}
+          </View>
+        </View>
+
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>Feature highlights</Text>
+          <View style={styles.featureList}>
+            {featureHighlights.map((feature) => (
+              <View key={feature.title} style={styles.featureCard}>
+                <Text style={styles.featureTitle}>{feature.title}</Text>
+                <Text style={styles.featureCopy}>{feature.copy}</Text>
+              </View>
+            ))}
+          </View>
+        </View>
+
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>Design opportunities</Text>
+          <View style={styles.designList}>
+            {designOpportunities.map((idea) => (
+              <View key={idea} style={styles.designIdea}>
+                <Text style={styles.designIdeaText}>{idea}</Text>
+              </View>
+            ))}
+          </View>
+        </View>
+
+        <BannerAdSlot unitId={homeBannerAdUnitId} size={defaultBannerSize} />
+      </ScrollView>
+    </AuthenticatedScreenContainer>
   );
 };
 
 const styles = StyleSheet.create({
-  safeArea: {
-    flex: 1,
-    backgroundColor: '#f3f4f6',
+  container: {
+    backgroundColor: '#eef2ff',
   },
-  content: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-    paddingHorizontal: 24,
+  scrollContent: {
+    paddingVertical: 24,
+    paddingHorizontal: 20,
+    gap: 24,
+  },
+  heroCard: {
+    backgroundColor: '#1d4ed8',
+    borderRadius: 24,
+    padding: 24,
+    gap: 12,
+  },
+  eyebrow: {
+    fontSize: 13,
+    textTransform: 'uppercase',
+    letterSpacing: 1.2,
+    fontWeight: '600',
+    color: '#bfdbfe',
   },
   title: {
-    fontSize: 24,
+    fontSize: 26,
     fontWeight: '700',
-    marginBottom: 32,
-    textAlign: 'center',
+    color: '#ffffff',
+    lineHeight: 32,
   },
-  subtitle: {
+  helperText: {
+    fontSize: 14,
+    color: '#e2e8f0',
+    lineHeight: 20,
+  },
+  section: {
+    backgroundColor: '#ffffff',
+    borderRadius: 20,
+    padding: 20,
+    gap: 16,
+    shadowColor: '#1e293b',
+    shadowOpacity: 0.08,
+    shadowRadius: 12,
+    shadowOffset: { width: 0, height: 4 },
+    elevation: 2,
+  },
+  sectionTitle: {
+    fontSize: 18,
+    fontWeight: '700',
+    color: '#1f2937',
+  },
+  quickActionGrid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 12,
+  },
+  quickActionCard: {
+    flexBasis: '48%',
+    backgroundColor: '#eff6ff',
+    borderRadius: 16,
+    paddingVertical: 18,
+    paddingHorizontal: 14,
+    borderWidth: 1,
+    borderColor: '#dbeafe',
+    gap: 8,
+  },
+  quickActionLabel: {
+    fontSize: 15,
+    fontWeight: '700',
+    color: '#1e40af',
+  },
+  quickActionDescription: {
+    fontSize: 12,
+    color: '#1d4ed8',
+  },
+  featureList: {
+    gap: 12,
+  },
+  featureCard: {
+    padding: 16,
+    borderRadius: 16,
+    backgroundColor: '#f8fafc',
+    borderWidth: 1,
+    borderColor: '#e2e8f0',
+    gap: 8,
+  },
+  featureTitle: {
     fontSize: 16,
-    color: '#4b5563',
-    marginBottom: 24,
-    textAlign: 'center',
+    fontWeight: '700',
+    color: '#0f172a',
   },
-  buttonGroup: {
-    width: '100%',
+  featureCopy: {
+    fontSize: 13,
+    color: '#475569',
+    lineHeight: 18,
   },
-  buttonWrapper: {
-    marginBottom: 12,
+  designList: {
+    gap: 12,
+  },
+  designIdea: {
+    backgroundColor: '#f3f4f6',
+    borderRadius: 14,
+    padding: 14,
+    borderWidth: 1,
+    borderColor: '#e5e7eb',
+  },
+  designIdeaText: {
+    fontSize: 13,
+    color: '#1f2937',
+    lineHeight: 18,
   },
 });
 

--- a/football-app/src/screens/ManageTeamScreen.tsx
+++ b/football-app/src/screens/ManageTeamScreen.tsx
@@ -11,7 +11,6 @@ import {
   TouchableOpacity,
   View,
 } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
 import { RouteProp, useNavigation, useRoute } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 
@@ -25,6 +24,7 @@ import {
   defaultTeamSettings,
   updateTeam,
 } from '../store/slices/teamsSlice';
+import AuthenticatedScreenContainer from '../components/AuthenticatedScreenContainer';
 import PitchFormation from '../components/PitchFormation';
 
 type ManageTeamRouteProp = RouteProp<RootStackParamList, 'ManageTeam'>;
@@ -395,30 +395,30 @@ const ManageTeamScreen: React.FC = () => {
 
   if (!teamId) {
     return (
-      <SafeAreaView style={styles.safeArea}>
-        <View style={styles.content}>
+      <AuthenticatedScreenContainer style={styles.safeArea} contentStyle={styles.messageContainer}>
+        <View style={styles.messageCard}>
           <Text style={styles.title}>Team unavailable</Text>
           <Text style={styles.subtitle}>
             We could not determine which team you wanted to manage. Please go back and try again.
           </Text>
         </View>
-      </SafeAreaView>
+      </AuthenticatedScreenContainer>
     );
   }
 
   if (!team) {
     return (
-      <SafeAreaView style={styles.safeArea}>
-        <View style={styles.content}>
+      <AuthenticatedScreenContainer style={styles.safeArea} contentStyle={styles.messageContainer}>
+        <View style={styles.messageCard}>
           <Text style={styles.title}>Team not found</Text>
           <Text style={styles.subtitle}>The team you are trying to manage could not be located.</Text>
         </View>
-      </SafeAreaView>
+      </AuthenticatedScreenContainer>
     );
   }
 
   return (
-    <SafeAreaView style={styles.safeArea}>
+    <AuthenticatedScreenContainer style={styles.safeArea}>
       <ScrollView contentContainerStyle={styles.scrollContent}>
         <View style={styles.section}>
           <Text style={styles.title}>Team details</Text>
@@ -724,7 +724,7 @@ const ManageTeamScreen: React.FC = () => {
           <Text style={styles.saveButtonText}>Save changes</Text>
         </TouchableOpacity>
       </ScrollView>
-    </SafeAreaView>
+    </AuthenticatedScreenContainer>
   );
 };
 
@@ -733,11 +733,22 @@ const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: '#f8fafc',
   },
-  content: {
+  messageContainer: {
     flex: 1,
-    padding: 24,
     justifyContent: 'center',
+    padding: 24,
+  },
+  messageCard: {
     backgroundColor: '#fff',
+    borderRadius: 16,
+    padding: 24,
+    alignItems: 'center',
+    gap: 12,
+    shadowColor: '#0f172a',
+    shadowOpacity: 0.08,
+    shadowRadius: 12,
+    shadowOffset: { width: 0, height: 4 },
+    elevation: 2,
   },
   scrollContent: {
     padding: 24,

--- a/football-app/src/screens/ProfileScreen.tsx
+++ b/football-app/src/screens/ProfileScreen.tsx
@@ -1,5 +1,4 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { SafeAreaView } from 'react-native-safe-area-context';
 import {
   ActivityIndicator,
   Alert,
@@ -19,6 +18,7 @@ import { useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import type { Product, ProductPurchase, PurchaseError } from 'react-native-iap';
 
+import AuthenticatedScreenContainer from '../components/AuthenticatedScreenContainer';
 import { useAppDispatch, useAppSelector } from '../store/hooks';
 import { creditWallet } from '../store/slices/walletSlice';
 import type {
@@ -751,7 +751,7 @@ const ProfileScreen: React.FC = () => {
   };
 
   return (
-    <SafeAreaView style={styles.safeArea}>
+    <AuthenticatedScreenContainer style={styles.safeArea}>
       <ScrollView contentContainerStyle={styles.scrollContent}>
         <View style={styles.header}>
           <Text style={styles.title}>Profile</Text>
@@ -1274,7 +1274,7 @@ const ProfileScreen: React.FC = () => {
           </View>
         </Modal>
       )}
-    </SafeAreaView>
+    </AuthenticatedScreenContainer>
   );
 };
 
@@ -1287,6 +1287,7 @@ const styles = StyleSheet.create({
     flexGrow: 1,
     padding: 24,
     gap: 24,
+    paddingBottom: 48,
   },
   header: {
     alignItems: 'center',

--- a/football-app/src/screens/TeamScreen.tsx
+++ b/football-app/src/screens/TeamScreen.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { StyleSheet, View, Text, FlatList, Button } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { useNavigation } from '@react-navigation/native';
 
+import AuthenticatedScreenContainer from '../components/AuthenticatedScreenContainer';
 import TeamCard from '../components/TeamCard';
 import BannerAdSlot from '../components/BannerAdSlot';
 import { defaultBannerSize, teamBannerAdUnitId } from '../config/ads';
@@ -21,46 +21,44 @@ const TeamScreen: React.FC = () => {
   const navigation = useNavigation<TeamScreenNavigationProp>();
 
   return (
-    <SafeAreaView style={styles.safeArea}>
-      <View style={styles.content}>
-        <Text style={styles.title}>My Teams</Text>
-        <FlatList
-          data={teams}
-          keyExtractor={(item: Team) => item.id}
-          contentContainerStyle={styles.listContent}
-          renderItem={({ item }: { item: Team }) => (
-            <TeamCard
-              team={item}
-              onRemove={() => dispatch(removeTeam(item.id))}
-              onManage={() => navigation.navigate('ManageTeam', { teamId: item.id })}
-            />
-          )}
-          ListEmptyComponent={<Text style={styles.emptyText}>Create your first team to get started.</Text>}
-        />
+    <AuthenticatedScreenContainer style={styles.safeArea} contentStyle={styles.content}>
+      <Text style={styles.title}>My Teams</Text>
+      <FlatList
+        data={teams}
+        keyExtractor={(item: Team) => item.id}
+        contentContainerStyle={styles.listContent}
+        renderItem={({ item }: { item: Team }) => (
+          <TeamCard
+            team={item}
+            onRemove={() => dispatch(removeTeam(item.id))}
+            onManage={() => navigation.navigate('ManageTeam', { teamId: item.id })}
+          />
+        )}
+        ListEmptyComponent={<Text style={styles.emptyText}>Create your first team to get started.</Text>}
+      />
 
-        <View style={styles.analyticsSection}>
-          <Text style={styles.analyticsTitle}>Team analytics</Text>
-          {isPremium ? (
-            <View style={styles.analyticsContent}>
-              <Text style={styles.analyticsMetric}>Form (last 5): W • W • D • L • W</Text>
-              <Text style={styles.analyticsMetric}>Projected seed: #3 in current tournament</Text>
-              <Text style={styles.analyticsHint}>
-                These insights refresh automatically after each recorded match.
-              </Text>
-            </View>
-          ) : (
-            <View style={styles.analyticsUpsell}>
-              <Text style={styles.analyticsUpsellText}>
-                Upgrade to Football App Premium to unlock match insights and projections.
-              </Text>
-              <Button title="View premium" onPress={() => navigation.navigate('Profile')} />
-            </View>
-          )}
-        </View>
-        <Button title="Create New Team" onPress={() => navigation.navigate('CreateTeam')} />
+      <View style={styles.analyticsSection}>
+        <Text style={styles.analyticsTitle}>Team analytics</Text>
+        {isPremium ? (
+          <View style={styles.analyticsContent}>
+            <Text style={styles.analyticsMetric}>Form (last 5): W • W • D • L • W</Text>
+            <Text style={styles.analyticsMetric}>Projected seed: #3 in current tournament</Text>
+            <Text style={styles.analyticsHint}>
+              These insights refresh automatically after each recorded match.
+            </Text>
+          </View>
+        ) : (
+          <View style={styles.analyticsUpsell}>
+            <Text style={styles.analyticsUpsellText}>
+              Upgrade to Football App Premium to unlock match insights and projections.
+            </Text>
+            <Button title="View premium" onPress={() => navigation.navigate('Profile')} />
+          </View>
+        )}
       </View>
+      <Button title="Create New Team" onPress={() => navigation.navigate('CreateTeam')} />
       <BannerAdSlot unitId={teamBannerAdUnitId} size={defaultBannerSize} />
-    </SafeAreaView>
+    </AuthenticatedScreenContainer>
   );
 };
 
@@ -70,9 +68,9 @@ const styles = StyleSheet.create({
     backgroundColor: '#f9fafb',
   },
   content: {
-    flex: 1,
     paddingHorizontal: 16,
     paddingTop: 16,
+    gap: 16,
   },
   title: {
     fontSize: 24,

--- a/football-app/src/screens/TournamentScreen.tsx
+++ b/football-app/src/screens/TournamentScreen.tsx
@@ -1,11 +1,11 @@
 import React, { useCallback, useEffect, useMemo } from 'react';
 import { StyleSheet, View, Text, Button, Alert } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
 import { useRewardedAd } from 'react-native-google-mobile-ads';
 
 import { tournamentRewardedAdUnitId } from '../config/ads';
 import { useAppDispatch, useAppSelector } from '../store/hooks';
 import { creditWallet } from '../store/slices/walletSlice';
+import AuthenticatedScreenContainer from '../components/AuthenticatedScreenContainer';
 
 const FALLBACK_REWARD_AMOUNT = 5;
 
@@ -53,40 +53,37 @@ const TournamentScreen: React.FC = () => {
   }, [error]);
 
   return (
-    <SafeAreaView style={styles.safeArea}>
-      <View style={styles.content}>
-        <Text style={styles.title}>Tournaments</Text>
-        <Text style={styles.subtitle}>Earn credits to enter premium tournaments.</Text>
+    <AuthenticatedScreenContainer style={styles.safeArea} contentStyle={styles.content}>
+      <Text style={styles.title}>Tournaments</Text>
+      <Text style={styles.subtitle}>Earn credits to enter premium tournaments.</Text>
 
-        <View style={styles.rewardCard}>
-          <Text style={styles.rewardTitle}>Wallet Balance</Text>
-          <Text style={styles.rewardAmount}>{credits} credits</Text>
-          <Button
-            title={isLoaded ? 'Watch to earn entry credits' : 'Load rewarded ad'}
-            onPress={handleWatchToEarn}
-          />
-          {!isLoaded && (
-            <Text style={styles.helperText}>Tap the button again if the ad is still loading.</Text>
-          )}
-        </View>
-
-        {isPremium ? (
-          <View style={styles.premiumInsights}>
-            <Text style={styles.premiumInsightsTitle}>Premium tournament insights</Text>
-            <Text style={styles.premiumInsightsDetail}>Next best event: Elite Cup (opens in 3 days)</Text>
-            <Text style={styles.premiumInsightsDetail}>Recommended entry fee budget: 120 credits</Text>
-          </View>
-        ) : (
-          <View style={styles.premiumUpsell}>
-            <Text style={styles.premiumUpsellText}>
-              Premium members get tournament recommendations tailored to their squad. Unlock from
-              the Profile screen.
-            </Text>
-          </View>
+      <View style={styles.rewardCard}>
+        <Text style={styles.rewardTitle}>Wallet Balance</Text>
+        <Text style={styles.rewardAmount}>{credits} credits</Text>
+        <Button
+          title={isLoaded ? 'Watch to earn entry credits' : 'Load rewarded ad'}
+          onPress={handleWatchToEarn}
+        />
+        {!isLoaded && (
+          <Text style={styles.helperText}>Tap the button again if the ad is still loading.</Text>
         )}
       </View>
-    </SafeAreaView>
 
+      {isPremium ? (
+        <View style={styles.premiumInsights}>
+          <Text style={styles.premiumInsightsTitle}>Premium tournament insights</Text>
+          <Text style={styles.premiumInsightsDetail}>Next best event: Elite Cup (opens in 3 days)</Text>
+          <Text style={styles.premiumInsightsDetail}>Recommended entry fee budget: 120 credits</Text>
+        </View>
+      ) : (
+        <View style={styles.premiumUpsell}>
+          <Text style={styles.premiumUpsellText}>
+            Premium members get tournament recommendations tailored to their squad. Unlock from the
+            Profile screen.
+          </Text>
+        </View>
+      )}
+    </AuthenticatedScreenContainer>
   );
 };
 
@@ -96,8 +93,8 @@ const styles = StyleSheet.create({
     backgroundColor: '#fff',
   },
   content: {
-    flex: 1,
     padding: 24,
+    gap: 20,
   },
   title: {
     fontSize: 28,


### PR DESCRIPTION
## Summary
- introduce an authenticated screen container with a persistent bottom navigation bar so logged-in users can switch areas without losing context
- refresh the home dashboard with scrollable quick actions, feature highlights, and design opportunity callouts
- align team, tournament, profile, and admin screens with the shared scaffold and document new feature and design ideas

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e5aa888858832ea66fdca5d76f297b