### PR TITLE
Automatically install Expo dependencies before linking

### DIFF
--- a/football-app/package.json
+++ b/football-app/package.json
@@ -67,6 +67,12 @@
     "react-redux",
     "redux"
   ],
+  "optionalShims": [
+    "@react-native-async-storage/async-storage",
+    "react-native-google-mobile-ads",
+    "react-native-iap",
+    "react-navigation"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/yourusername/football-app.git"

--- a/football-app/scripts/link-node-modules.js
+++ b/football-app/scripts/link-node-modules.js
@@ -2,12 +2,80 @@ const fs = require('fs');
 const path = require('path');
 
 const projectRoot = path.resolve(__dirname, '..');
-const expoNodeModules = path.join(projectRoot, 'football-app-expo', 'node_modules');
+const expoProjectRoot = path.join(projectRoot, 'football-app-expo');
+const expoNodeModules = path.join(expoProjectRoot, 'node_modules');
+const packageJsonPath = path.join(projectRoot, 'package.json');
+const expoPackageJsonPath = path.join(expoProjectRoot, 'package.json');
 const targetLink = path.join(projectRoot, 'node_modules');
+
+function installExpoDependencies(reason) {
+  console.log(`${reason}\nInstalling Expo workspace dependencies…`);
+
+  const { spawnSync } = require('child_process');
+  const result = spawnSync('npm', ['install', '--no-audit', '--no-fund'], {
+    cwd: expoProjectRoot,
+    stdio: 'inherit',
+    shell: process.platform === 'win32',
+  });
+
+  if (result.status !== 0) {
+    throw new Error(`Failed to install Expo workspace dependencies (exit code ${result.status ?? 'unknown'}).`);
+  }
+}
+
+function readJson(filePath) {
+  try {
+    const raw = fs.readFileSync(filePath, 'utf8');
+    return JSON.parse(raw);
+  } catch (error) {
+    throw new Error(`Unable to read ${filePath}: ${error.message}`);
+  }
+}
+
+function listExpectedModules() {
+  const packageJson = readJson(packageJsonPath);
+  const expoPackageJson = readJson(expoPackageJsonPath);
+
+  const optionalShims = new Set(packageJson.optionalShims || []);
+  const expected = new Set([
+    ...(packageJson.localDependencies || []),
+    ...Object.keys(packageJson.vendoredDependencies || {}),
+    ...Object.keys(expoPackageJson.dependencies || {}),
+  ]);
+
+  // Some dependencies are intentionally shimmed for web/testing and are not
+  // expected to be installed in the Expo workspace. Allow the package.json to
+  // declare them via an optionalShims array so they do not trigger unnecessary
+  // installs during automation.
+  optionalShims.forEach((name) => expected.delete(name));
+
+  return Array.from(expected);
+}
 
 function ensureExpoModulesExist() {
   if (!fs.existsSync(expoNodeModules)) {
-    throw new Error(`Expected Expo dependencies at ${expoNodeModules}, but the directory was not found.`);
+    installExpoDependencies(`Expected Expo dependencies at ${expoNodeModules}, but the directory was not found.`);
+  }
+
+  const missingModules = () =>
+    listExpectedModules().filter((name) => {
+      const modulePath = path.join(expoNodeModules, ...name.split('/'));
+      return !fs.existsSync(modulePath);
+    });
+
+  let missing = missingModules();
+
+  if (missing.length > 0) {
+    installExpoDependencies(
+      `Missing Expo dependencies detected (${missing.join(', ')}).`
+    );
+    missing = missingModules();
+  }
+
+  if (missing.length > 0) {
+    throw new Error(
+      `Expo dependencies are still missing after installation: ${missing.join(', ')}`
+    );
   }
 }
 


### PR DESCRIPTION
## Summary
- ensure the link-node-modules helper installs missing Expo workspace dependencies before linking
- allow optional shimmed packages to be skipped from dependency verification via package.json

## Testing
- npm test -- --watch=false
- npm run deploy:web

------
https://chatgpt.com/codex/tasks/task_e_68e5bc0263cc832eb3354faaca2b541c