### PR TITLE
Ensure profile email defaults to account address

### DIFF
--- a/football-app/src/screens/ProfileScreen.tsx
+++ b/football-app/src/screens/ProfileScreen.tsx
@@ -208,17 +208,31 @@ const ProfileScreen: React.FC = () => {
       return;
     }
 
-    setProfileForm((prev) => {
-      if (prev.email && prev.email.trim().length > 0) {
-        return prev;
-      }
+    const normalisedAccountEmail = currentUser.email.trim().toLowerCase();
+    const profileEmail = profile.email.trim().toLowerCase();
 
-      return {
-        ...prev,
-        email: currentUser.email,
-      };
-    });
-  }, [currentUser?.email]);
+    if (profileEmail.length === 0) {
+      setProfileForm((prev) => {
+        const existingEmail = prev.email.trim().toLowerCase();
+        if (existingEmail.length > 0 && existingEmail !== normalisedAccountEmail) {
+          return prev;
+        }
+
+        if (existingEmail === normalisedAccountEmail) {
+          return prev;
+        }
+
+        return {
+          ...prev,
+          email: normalisedAccountEmail,
+        };
+      });
+
+      if (profileEmail !== normalisedAccountEmail) {
+        dispatch(updateProfile({ email: normalisedAccountEmail }));
+      }
+    }
+  }, [currentUser?.email, dispatch, profile.email]);
 
   useEffect(() => {
     let cancelled = false;


### PR DESCRIPTION
## Summary
- default the profile form email field to the logged-in account email when no email is stored
- sync the profile state with the account email so the value persists for saving and storage

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e5c22395a0832e8602844dee8eabc1