### PR TITLE
Add social and mobile authentication options

### DIFF
--- a/football-app/src/screens/LoginScreen.tsx
+++ b/football-app/src/screens/LoginScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import {
   Alert,
   KeyboardAvoidingView,
@@ -16,12 +16,16 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { RootStackParamList } from '../types/navigation';
 import { useAppDispatch, useAppSelector } from '../store/hooks';
 import {
+  authenticateWithSocialProvider,
   loginUser,
   loginWithBiometrics,
+  loginWithMobileNumber,
   selectAuthLoading,
   selectBiometricEnabledUsers,
 } from '../store/slices/authSlice';
 import { detectBiometricSupport, requestBiometricAuthentication } from '../services/biometricAuth';
+import { getMockOtpCode, sendMockOtpToPhone, verifyMockOtpCode } from '../services/mobileAuth';
+import type { SocialProvider } from '../services/socialAuth';
 
 interface LoginScreenProps {
   navigation: NativeStackNavigationProp<RootStackParamList, 'Login'>;
@@ -36,6 +40,13 @@ const LoginScreen: React.FC<LoginScreenProps> = ({ navigation }) => {
   const [submitting, setSubmitting] = useState(false);
   const [biometricError, setBiometricError] = useState<string | null>(null);
   const [biometricLoading, setBiometricLoading] = useState<string | null>(null);
+  const [activeSocialProvider, setActiveSocialProvider] = useState<SocialProvider | null>(null);
+  const [mobileNumber, setMobileNumber] = useState('');
+  const [mobileCode, setMobileCode] = useState('');
+  const [mobileOtpSent, setMobileOtpSent] = useState(false);
+  const [mobileSending, setMobileSending] = useState(false);
+  const [mobileSubmitting, setMobileSubmitting] = useState(false);
+  const demoOtpCode = useMemo(() => getMockOtpCode(), []);
 
   const handleSubmit = useCallback(async () => {
     if (!email.trim() || !password.trim()) {
@@ -53,6 +64,86 @@ const LoginScreen: React.FC<LoginScreenProps> = ({ navigation }) => {
       setSubmitting(false);
     }
   }, [dispatch, email, password]);
+
+  const handleSocialSignIn = useCallback(
+    async (provider: SocialProvider) => {
+      if (activeSocialProvider) {
+        return;
+      }
+
+      setActiveSocialProvider(provider);
+      try {
+        await dispatch(authenticateWithSocialProvider({ provider })).unwrap();
+      } catch (error) {
+        const message =
+          typeof error === 'string'
+            ? error
+            : 'Unable to connect to that provider right now. Please try again.';
+        Alert.alert('Sign in failed', message);
+      } finally {
+        setActiveSocialProvider(null);
+      }
+    },
+    [activeSocialProvider, dispatch],
+  );
+
+  const handleSendMobileOtp = useCallback(async () => {
+    if (!mobileNumber.trim()) {
+      Alert.alert('Missing mobile number', 'Enter your mobile number to receive a code.');
+      return;
+    }
+
+    setMobileSending(true);
+    try {
+      const code = await sendMockOtpToPhone(mobileNumber);
+      setMobileOtpSent(true);
+      Alert.alert('Verification code sent', `Use code ${code} to verify your mobile number.`);
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : 'We could not send a verification code. Please try again shortly.';
+      Alert.alert('Unable to send code', message);
+    } finally {
+      setMobileSending(false);
+    }
+  }, [mobileNumber]);
+
+  const handleMobileLogin = useCallback(async () => {
+    if (!mobileNumber.trim()) {
+      Alert.alert('Missing mobile number', 'Enter your mobile number to continue.');
+      return;
+    }
+
+    if (!mobileOtpSent) {
+      Alert.alert('Verification required', 'Send yourself a verification code first.');
+      return;
+    }
+
+    if (!mobileCode.trim()) {
+      Alert.alert('Missing code', 'Enter the 6-digit verification code.');
+      return;
+    }
+
+    setMobileSubmitting(true);
+    try {
+      const verified = await verifyMockOtpCode(mobileCode);
+      if (!verified) {
+        Alert.alert('Invalid code', 'The verification code you entered is incorrect.');
+        return;
+      }
+
+      await dispatch(loginWithMobileNumber({ phoneNumber: mobileNumber })).unwrap();
+      setMobileCode('');
+      setMobileOtpSent(false);
+    } catch (error) {
+      const message =
+        typeof error === 'string' ? error : 'Unable to sign in with that mobile number right now.';
+      Alert.alert('Sign in failed', message);
+    } finally {
+      setMobileSubmitting(false);
+    }
+  }, [dispatch, mobileCode, mobileNumber, mobileOtpSent]);
 
   const handleBiometricLogin = useCallback(
     async (userId: string) => {
@@ -116,6 +207,113 @@ const LoginScreen: React.FC<LoginScreenProps> = ({ navigation }) => {
           <Text style={styles.title}>Welcome back</Text>
           <Text style={styles.subtitle}>Sign in to manage your teams and competitions.</Text>
 
+          <View style={styles.quickActionsCard}>
+            <Text style={styles.quickActionsTitle}>Quick sign in</Text>
+            <Text style={styles.quickActionsSubtitle}>
+              Choose a social account or verify with your mobile number.
+            </Text>
+
+            <TouchableOpacity
+              style={[
+                styles.socialButton,
+                styles.googleButton,
+                (activeSocialProvider && activeSocialProvider !== 'google') || loading
+                  ? styles.socialButtonDisabled
+                  : null,
+              ]}
+              onPress={() => handleSocialSignIn('google')}
+              disabled={
+                !!activeSocialProvider || loading || submitting || mobileSubmitting || mobileSending
+              }
+            >
+              <Text style={styles.socialButtonText}>
+                {activeSocialProvider === 'google' ? 'Connecting to Google…' : 'Continue with Google'}
+              </Text>
+            </TouchableOpacity>
+
+            <TouchableOpacity
+              style={[
+                styles.socialButton,
+                styles.facebookButton,
+                (activeSocialProvider && activeSocialProvider !== 'facebook') || loading
+                  ? styles.socialButtonDisabled
+                  : null,
+              ]}
+              onPress={() => handleSocialSignIn('facebook')}
+              disabled={
+                !!activeSocialProvider || loading || submitting || mobileSubmitting || mobileSending
+              }
+            >
+              <Text style={[styles.socialButtonText, styles.facebookButtonText]}>
+                {activeSocialProvider === 'facebook'
+                  ? 'Connecting to Facebook…'
+                  : 'Continue with Facebook'}
+              </Text>
+            </TouchableOpacity>
+
+            <View style={styles.dividerRow}>
+              <View style={styles.dividerLine} />
+              <Text style={styles.dividerText}>or mobile number</Text>
+              <View style={styles.dividerLine} />
+            </View>
+
+            <View style={styles.fieldGroup}>
+              <Text style={styles.label}>Mobile number</Text>
+              <TextInput
+                value={mobileNumber}
+                onChangeText={setMobileNumber}
+                keyboardType="phone-pad"
+                placeholder="e.g. +44 7123 456 789"
+                style={styles.input}
+                textContentType="telephoneNumber"
+              />
+            </View>
+
+            <View style={styles.fieldGroup}>
+              <Text style={styles.label}>Verification code</Text>
+              <TextInput
+                value={mobileCode}
+                onChangeText={setMobileCode}
+                keyboardType="number-pad"
+                placeholder="Enter 6-digit code"
+                style={styles.input}
+                maxLength={6}
+              />
+              <Text style={styles.helperText}>Demo code: {demoOtpCode}</Text>
+            </View>
+
+            <View style={styles.mobileActions}>
+              <TouchableOpacity
+                style={[styles.tertiaryButton, mobileSending && styles.tertiaryButtonDisabled]}
+                onPress={handleSendMobileOtp}
+                disabled={mobileSending || loading}
+              >
+                <Text style={styles.tertiaryButtonText}>
+                  {mobileSending ? 'Sending…' : mobileOtpSent ? 'Resend code' : 'Send code'}
+                </Text>
+              </TouchableOpacity>
+              <TouchableOpacity
+                style={[
+                  styles.primaryButton,
+                  styles.mobilePrimaryButton,
+                  (loading || mobileSubmitting) && styles.primaryButtonDisabled,
+                ]}
+                onPress={handleMobileLogin}
+                disabled={loading || mobileSubmitting}
+              >
+                <Text style={styles.primaryButtonText}>
+                  {loading || mobileSubmitting ? 'Verifying…' : 'Sign in with mobile'}
+                </Text>
+              </TouchableOpacity>
+            </View>
+          </View>
+
+          <View style={[styles.dividerRow, styles.emailDivider]}>
+            <View style={styles.dividerLine} />
+            <Text style={styles.dividerText}>or use email</Text>
+            <View style={styles.dividerLine} />
+          </View>
+
           <View style={styles.fieldGroup}>
             <Text style={styles.label}>Email</Text>
             <TextInput
@@ -147,7 +345,7 @@ const LoginScreen: React.FC<LoginScreenProps> = ({ navigation }) => {
             disabled={loading || submitting}
           >
             <Text style={styles.primaryButtonText}>
-              {loading || submitting ? 'Signing in…' : 'Sign in'}
+              {loading || submitting ? 'Signing in…' : 'Sign in with email'}
             </Text>
           </TouchableOpacity>
 
@@ -163,6 +361,14 @@ const LoginScreen: React.FC<LoginScreenProps> = ({ navigation }) => {
               </Text>
               {biometricUsers.map((user) => {
                 const isAuthenticating = biometricLoading === user.id;
+                const identifier =
+                  user.authProvider === 'mobile' && user.phoneNumber
+                    ? `${user.phoneNumber} · Mobile`
+                    : user.authProvider === 'google'
+                    ? `${user.email} · Google`
+                    : user.authProvider === 'facebook'
+                    ? `${user.email} · Facebook`
+                    : user.email;
                 return (
                   <TouchableOpacity
                     key={user.id}
@@ -177,7 +383,7 @@ const LoginScreen: React.FC<LoginScreenProps> = ({ navigation }) => {
                     <Text style={styles.biometricButtonText}>
                       {isAuthenticating ? 'Authenticating…' : `Sign in as ${user.fullName}`}
                     </Text>
-                    <Text style={styles.biometricButtonEmail}>{user.email}</Text>
+                    <Text style={styles.biometricButtonEmail}>{identifier}</Text>
                   </TouchableOpacity>
                 );
               })}
@@ -222,6 +428,26 @@ const styles = StyleSheet.create({
     marginBottom: 24,
     textAlign: 'center',
   },
+  quickActionsCard: {
+    backgroundColor: '#1e293b',
+    borderRadius: 12,
+    padding: 20,
+    borderWidth: 1,
+    borderColor: '#334155',
+    marginBottom: 24,
+  },
+  quickActionsTitle: {
+    color: '#f8fafc',
+    fontSize: 18,
+    fontWeight: '700',
+    marginBottom: 4,
+  },
+  quickActionsSubtitle: {
+    color: '#cbd5f5',
+    fontSize: 14,
+    marginBottom: 16,
+    lineHeight: 20,
+  },
   fieldGroup: {
     marginBottom: 16,
   },
@@ -238,6 +464,80 @@ const styles = StyleSheet.create({
     color: '#f8fafc',
     borderWidth: 1,
     borderColor: '#334155',
+  },
+  socialButton: {
+    borderRadius: 8,
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+    marginBottom: 12,
+    alignItems: 'center',
+  },
+  googleButton: {
+    backgroundColor: '#f8fafc',
+  },
+  facebookButton: {
+    backgroundColor: '#1d4ed8',
+  },
+  socialButtonText: {
+    fontWeight: '700',
+    color: '#0f172a',
+    fontSize: 15,
+  },
+  facebookButtonText: {
+    color: '#f8fafc',
+  },
+  socialButtonDisabled: {
+    opacity: 0.7,
+  },
+  dividerRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginVertical: 12,
+    justifyContent: 'center',
+  },
+  dividerLine: {
+    flex: 1,
+    height: StyleSheet.hairlineWidth,
+    backgroundColor: '#334155',
+  },
+  dividerText: {
+    color: '#cbd5f5',
+    fontSize: 12,
+    textTransform: 'uppercase',
+    letterSpacing: 1,
+    marginHorizontal: 12,
+  },
+  helperText: {
+    color: '#94a3b8',
+    fontSize: 12,
+    marginTop: 8,
+  },
+  mobileActions: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginTop: 8,
+  },
+  tertiaryButton: {
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: '#475569',
+    marginRight: 12,
+  },
+  tertiaryButtonDisabled: {
+    opacity: 0.7,
+  },
+  tertiaryButtonText: {
+    color: '#e2e8f0',
+    fontWeight: '600',
+  },
+  mobilePrimaryButton: {
+    flex: 1,
+  },
+  emailDivider: {
+    marginTop: 8,
+    marginBottom: 24,
   },
   primaryButton: {
     backgroundColor: '#2563eb',

--- a/football-app/src/screens/ProfileScreen.tsx
+++ b/football-app/src/screens/ProfileScreen.tsx
@@ -172,6 +172,26 @@ const ProfileScreen: React.FC = () => {
     [profileForm, premium.entitled],
   );
 
+  const accountIdentifier = useMemo(() => {
+    if (!currentUser) {
+      return '';
+    }
+
+    if (currentUser.authProvider === 'mobile' && currentUser.phoneNumber) {
+      return `${currentUser.phoneNumber} · Mobile`;
+    }
+
+    if (currentUser.authProvider === 'google') {
+      return `${currentUser.email} · Google`;
+    }
+
+    if (currentUser.authProvider === 'facebook') {
+      return `${currentUser.email} · Facebook`;
+    }
+
+    return currentUser.email;
+  }, [currentUser]);
+
   useEffect(() => {
     let mounted = true;
 
@@ -818,7 +838,7 @@ const ProfileScreen: React.FC = () => {
             <View style={styles.accountHeader}>
               <View>
                 <Text style={styles.accountName}>{currentUser.fullName}</Text>
-                <Text style={styles.accountEmail}>{currentUser.email}</Text>
+                <Text style={styles.accountEmail}>{accountIdentifier}</Text>
               </View>
               <Text
                 style={[

--- a/football-app/src/services/mobileAuth.ts
+++ b/football-app/src/services/mobileAuth.ts
@@ -1,0 +1,20 @@
+const MOCK_OTP_CODE = '123456';
+
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+export const sendMockOtpToPhone = async (phoneNumber: string): Promise<string> => {
+  const digitsOnly = phoneNumber.replace(/[^\d+]/g, '');
+  if (!digitsOnly) {
+    throw new Error('A valid mobile number is required');
+  }
+
+  await delay(600);
+  return MOCK_OTP_CODE;
+};
+
+export const verifyMockOtpCode = async (code: string): Promise<boolean> => {
+  await delay(250);
+  return code.trim() === MOCK_OTP_CODE;
+};
+
+export const getMockOtpCode = () => MOCK_OTP_CODE;

--- a/football-app/src/services/socialAuth.ts
+++ b/football-app/src/services/socialAuth.ts
@@ -1,0 +1,32 @@
+export type SocialProvider = 'google' | 'facebook';
+
+export interface SocialProviderProfile {
+  provider: SocialProvider;
+  fullName: string;
+  email: string;
+  marketingOptIn?: boolean;
+}
+
+const PROVIDER_PROFILES: Record<SocialProvider, SocialProviderProfile> = {
+  google: {
+    provider: 'google',
+    fullName: 'Jordan Matthews',
+    email: 'jordan.matthews@gmail.com',
+    marketingOptIn: true,
+  },
+  facebook: {
+    provider: 'facebook',
+    fullName: 'Imani Clarke',
+    email: 'imani.clarke@facebookmail.com',
+    marketingOptIn: false,
+  },
+};
+
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+export const fetchMockSocialProfile = async (
+  provider: SocialProvider,
+): Promise<SocialProviderProfile> => {
+  await delay(600);
+  return { ...PROVIDER_PROFILES[provider] };
+};

--- a/football-app/src/types/user.ts
+++ b/football-app/src/types/user.ts
@@ -2,6 +2,8 @@ export type UserRole = 'user' | 'admin';
 
 export type UserStatus = 'active' | 'suspended';
 
+export type AuthProvider = 'email' | 'google' | 'facebook' | 'mobile';
+
 export interface UserAccount {
   id: string;
   fullName: string;
@@ -11,6 +13,8 @@ export interface UserAccount {
   status: UserStatus;
   createdAt: string;
   biometricEnabled: boolean;
+  authProvider: AuthProvider;
+  phoneNumber: string | null;
 }
 
 export interface StoredUserAccount extends UserAccount {


### PR DESCRIPTION
## Summary
- add mock Google and Facebook authentication flows that create or reuse accounts on demand
- support mobile number registration and login with OTP-style verification and shared marketing preferences
- refresh login, register, and profile screens to surface provider-specific contact details and new sign-in options

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e5c4d004bc832eaa05ac6dbb4f6939