### PR TITLE
Document app store enrollment fees

### DIFF
--- a/docs/phase-1-account-legal-playbook.md
+++ b/docs/phase-1-account-legal-playbook.md
@@ -17,7 +17,7 @@ This playbook expands the high-level Phase 1 items from the publishing action pl
    - [ ] Store sanitized evidence in `docs/publishing/evidence/accounts/`.
 2. **Document ownership & billing**
    - [ ] Record the primary owners, backup admins, and billing contacts for each store.
-   - [ ] Note renewal dates (Apple yearly fee, Play Console one-time) and add reminders to the team calendar.
+   - [ ] Note renewal dates (Apple yearly US\$99 USD fee, Google Play one-time US\$25 USD fee) and add reminders to the team calendar.
    - [ ] Save a `ACCOUNTS.md` summary in `docs/publishing`.
 3. **Set up access management**
    - [ ] Audit user roles, removing unused accounts and applying least-privilege roles.

--- a/docs/publishing-guide.md
+++ b/docs/publishing-guide.md
@@ -4,8 +4,8 @@ This checklist summarizes the key steps required to launch the application on bo
 
 ## Prerequisites
 - **Developer accounts**
-  - Enroll in the [Google Play Console](https://play.google.com/console) with a one-time registration fee.
-  - Enroll in the [Apple Developer Program](https://developer.apple.com/programs/) and maintain the annual membership.
+  - Enroll in the [Google Play Console](https://play.google.com/console) with a one-time US\$25 USD registration fee (or the local-currency equivalent collected by Google).
+  - Enroll in the [Apple Developer Program](https://developer.apple.com/programs/) and maintain the annual US\$99 USD membership (waived for approved nonprofits, schools, or governments).
 - **App assets ready**
   - Final app name, description, keywords, and privacy policy URL.
   - High-resolution icon, feature graphics, and screenshots that meet the store guidelines for all targeted devices.


### PR DESCRIPTION
## Summary
- spell out the current Google Play Console and Apple Developer Program enrollment costs in the publishing checklist
- clarify the account playbook so owners record the specific US$25 one-time Play fee and US$99 annual Apple renewal when scheduling billing reminders

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e5c2cdf81c832e8fd1601cd501f37c