### PR TITLE
Add AI kit design workflow and contextual team chat

### DIFF
--- a/football-app/src/components/KitDesignBoard.tsx
+++ b/football-app/src/components/KitDesignBoard.tsx
@@ -1,0 +1,880 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  TouchableOpacity,
+  TextInput,
+  ScrollView,
+} from 'react-native';
+
+import { useAppDispatch, useAppSelector } from '../store/hooks';
+import {
+  addConceptFeedback,
+  addConceptTask,
+  attachChatThread,
+  castConceptVote,
+  closeVotingWindow,
+  confirmKitOrder,
+  createProductionPackage,
+  exportConceptToCanva,
+  generateAIConcepts,
+  publishFinalKit,
+  requestVendorQuote,
+  scheduleVotingWindow,
+  selectCanvaTemplates,
+  selectKitProjectsByTeam,
+  selectKitPromptLibrary,
+  selectVendorCatalog,
+  startKitProject,
+  syncCanvaRevision,
+  updateConceptTaskStatus,
+  updateKitBrief,
+} from '../store/slices/kitDesignSlice';
+import { createContextualThread, selectThreadsByTeam } from '../store/slices/teamChatSlice';
+
+interface KitDesignBoardProps {
+  teamId: string;
+  teamName?: string;
+}
+
+const KitDesignBoard: React.FC<KitDesignBoardProps> = ({ teamId, teamName }) => {
+  const dispatch = useAppDispatch();
+  const projects = useAppSelector((state) => selectKitProjectsByTeam(state, teamId));
+  const project = projects[0];
+  const prompts = useAppSelector(selectKitPromptLibrary);
+  const templates = useAppSelector(selectCanvaTemplates);
+  const vendors = useAppSelector(selectVendorCatalog);
+  const threads = useAppSelector((state) => selectThreadsByTeam(state, teamId));
+  const kitThread = useMemo(
+    () => threads.find((thread) => thread.type === 'kit'),
+    [threads],
+  );
+
+  const [primaryColor, setPrimaryColor] = useState('#0f172a');
+  const [secondaryColor, setSecondaryColor] = useState('#facc15');
+  const [sponsor, setSponsor] = useState('');
+  const [vibe, setVibe] = useState('');
+  const [notes, setNotes] = useState('');
+  const [selectedPrompts, setSelectedPrompts] = useState<string[]>([]);
+  const [feedbackDrafts, setFeedbackDrafts] = useState<Record<string, string>>({});
+  const [taskDrafts, setTaskDrafts] = useState<Record<string, string>>({});
+  const [voteChoice, setVoteChoice] = useState<Record<string, 'approve' | 'revise'>>({});
+
+  useEffect(() => {
+    if (!project && !kitThread) {
+      return;
+    }
+
+    if (project && !project.chatThreadId && kitThread) {
+      dispatch(attachChatThread({ projectId: project.id, threadId: kitThread.id }));
+    }
+  }, [project, kitThread, dispatch]);
+
+  useEffect(() => {
+    if (!project) {
+      return;
+    }
+
+    setPrimaryColor(project.brief.primaryColor);
+    setSecondaryColor(project.brief.secondaryColor);
+    setSponsor(project.brief.sponsor);
+    setVibe(project.brief.vibe);
+    setNotes(project.brief.inspirationNotes ?? '');
+    setSelectedPrompts(project.prompts.map((prompt) => prompt.id));
+  }, [project?.id]);
+
+  const handleStartProject = () => {
+    if (!kitThread) {
+      dispatch(
+        createContextualThread({
+          teamId,
+          title: 'Kit Design Room',
+          type: 'kit',
+          createdBy: 'System',
+          metadata: { relatedKitProjectId: undefined },
+        }),
+      );
+    }
+
+    dispatch(
+      startKitProject({
+        teamId,
+        title: `${teamName ?? 'Squad'} 24/25 Home Kit`,
+        brief: {
+          primaryColor,
+          secondaryColor,
+          sponsor: sponsor || 'Local Sponsor',
+          vibe: vibe || 'Community-first energy',
+          inspirationNotes: notes,
+          culturalAnchors: ['Club crest evolution', 'Local landmark'],
+        },
+        chatThreadId: kitThread?.id,
+      }),
+    );
+  };
+
+  const handleSaveBrief = () => {
+    if (!project) {
+      return;
+    }
+
+    dispatch(
+      updateKitBrief({
+        projectId: project.id,
+        brief: {
+          primaryColor,
+          secondaryColor,
+          sponsor,
+          vibe,
+          inspirationNotes: notes,
+        },
+        promptIds: selectedPrompts,
+      }),
+    );
+  };
+
+  const handleGenerateConcepts = () => {
+    if (!project) {
+      return;
+    }
+
+    dispatch(generateAIConcepts({ projectId: project.id }));
+  };
+
+  const handleRequestQuote = (vendorId: string) => {
+    if (!project) {
+      return;
+    }
+
+    dispatch(requestVendorQuote({ projectId: project.id, vendorId }));
+  };
+
+  const handleConfirmOrder = () => {
+    if (!project || !project.vendorQuoteId) {
+      return;
+    }
+
+    dispatch(
+      confirmKitOrder({
+        projectId: project.id,
+        quoteId: project.vendorQuoteId,
+        paymentMethod: 'wallet',
+        quantities: { S: 5, M: 8, L: 8, XL: 4 },
+      }),
+    );
+  };
+
+  const handlePublish = () => {
+    if (!project) {
+      return;
+    }
+
+    dispatch(
+      publishFinalKit({
+        projectId: project.id,
+        showcaseUrl: `https://community.football.app/teams/${teamId}/kits/${project.id}`,
+      }),
+    );
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.sectionTitle}>AI-powered kit lab</Text>
+      {!project ? (
+        <View style={styles.emptyState}>
+          <Text style={styles.emptyTitle}>Start a collaborative kit project</Text>
+          <Text style={styles.emptyCopy}>
+            Capture the brief, spin up AI concepts, and bring your squad into the decision making loop with
+            structured feedback and voting.
+          </Text>
+          <View style={styles.briefGrid}>
+            <View style={styles.briefColumn}>
+              <Text style={styles.inputLabel}>Primary colour</Text>
+              <TextInput value={primaryColor} onChangeText={setPrimaryColor} style={styles.input} />
+              <Text style={styles.inputLabel}>Secondary colour</Text>
+              <TextInput value={secondaryColor} onChangeText={setSecondaryColor} style={styles.input} />
+              <Text style={styles.inputLabel}>Sponsor</Text>
+              <TextInput value={sponsor} onChangeText={setSponsor} style={styles.input} placeholder="Local business" />
+            </View>
+            <View style={styles.briefColumn}>
+              <Text style={styles.inputLabel}>Kit vibe</Text>
+              <TextInput value={vibe} onChangeText={setVibe} style={styles.input} placeholder="Bold, fearless, community" />
+              <Text style={styles.inputLabel}>Cultural anchors</Text>
+              <Text style={styles.anchorHelper}>
+                We automatically reference club history, city icons, and supporter rituals to seed AI prompts.
+              </Text>
+              <Text style={styles.inputLabel}>Additional notes</Text>
+              <TextInput
+                value={notes}
+                onChangeText={setNotes}
+                style={[styles.input, styles.multilineInput]}
+                placeholder="Highlight academy stripes and anniversary crest"
+                multiline
+              />
+            </View>
+          </View>
+          <TouchableOpacity style={styles.primaryButton} onPress={handleStartProject}>
+            <Text style={styles.primaryButtonText}>Launch kit workspace</Text>
+          </TouchableOpacity>
+        </View>
+      ) : (
+        <View style={styles.content}>
+          <Text style={styles.statusPill}>{project.stage.toUpperCase()}</Text>
+          <Text style={styles.subheading}>Design brief & inspiration</Text>
+          <View style={styles.briefGrid}>
+            <View style={styles.briefColumn}>
+              <Text style={styles.inputLabel}>Primary colour</Text>
+              <TextInput value={primaryColor} onChangeText={setPrimaryColor} style={styles.input} />
+              <Text style={styles.inputLabel}>Secondary colour</Text>
+              <TextInput value={secondaryColor} onChangeText={setSecondaryColor} style={styles.input} />
+              <Text style={styles.inputLabel}>Sponsor</Text>
+              <TextInput value={sponsor} onChangeText={setSponsor} style={styles.input} />
+            </View>
+            <View style={styles.briefColumn}>
+              <Text style={styles.inputLabel}>Kit vibe</Text>
+              <TextInput value={vibe} onChangeText={setVibe} style={styles.input} />
+              <Text style={styles.inputLabel}>Inspiration notes</Text>
+              <TextInput
+                value={notes}
+                onChangeText={setNotes}
+                style={[styles.input, styles.multilineInput]}
+                multiline
+              />
+            </View>
+          </View>
+          <ScrollView horizontal showsHorizontalScrollIndicator={false} style={styles.promptRow}>
+            {prompts.map((prompt) => {
+              const selected = selectedPrompts.includes(prompt.id);
+              return (
+                <TouchableOpacity
+                  key={prompt.id}
+                  style={[styles.promptCard, selected && styles.promptCardSelected]}
+                  onPress={() => {
+                    setSelectedPrompts((current) =>
+                      selected ? current.filter((id) => id !== prompt.id) : [...current, prompt.id],
+                    );
+                  }}
+                >
+                  <Text style={styles.promptTitle}>{prompt.title}</Text>
+                  <Text style={styles.promptCopy}>{prompt.description}</Text>
+                </TouchableOpacity>
+              );
+            })}
+          </ScrollView>
+          <TouchableOpacity style={styles.secondaryButton} onPress={handleSaveBrief}>
+            <Text style={styles.secondaryButtonText}>Save brief & prompt palette</Text>
+          </TouchableOpacity>
+
+          <Text style={styles.subheading}>AI + Canva co-creation</Text>
+          <Text style={styles.helperCopy}>
+            Generate layered concepts, then push any version directly into Canva for pixel-perfect tweaks.
+          </Text>
+          <TouchableOpacity style={styles.primaryButton} onPress={handleGenerateConcepts}>
+            <Text style={styles.primaryButtonText}>Generate concepts</Text>
+          </TouchableOpacity>
+          <ScrollView horizontal showsHorizontalScrollIndicator={false} style={styles.templateRow}>
+            {templates.map((template) => (
+              <View key={template.id} style={styles.templateCard}>
+                <View style={styles.templatePreview}>
+                  <Text style={styles.templatePreviewText}>{template.title}</Text>
+                </View>
+                <Text style={styles.templateCategory}>{template.category}</Text>
+                <Text style={styles.templateLink}>Open in Canva</Text>
+              </View>
+            ))}
+          </ScrollView>
+
+          <View style={styles.conceptsGrid}>
+            {project.concepts.map((concept) => {
+              const feedbackDraft = feedbackDrafts[concept.id] ?? '';
+              const taskDraft = taskDrafts[concept.id] ?? '';
+              const votes = concept.votes.reduce(
+                (acc, vote) => {
+                  if (vote.vote === 'approve') {
+                    acc.approve += 1;
+                  } else {
+                    acc.revise += 1;
+                  }
+                  return acc;
+                },
+                { approve: 0, revise: 0 },
+              );
+
+              return (
+                <View key={concept.id} style={styles.conceptCard}>
+                  <Text style={styles.conceptTitle}>{concept.title}</Text>
+                  <Text style={styles.conceptMeta}>Version {concept.version}</Text>
+                  <View style={styles.previewRow}>
+                    <View style={styles.previewBlock}>
+                      <Text style={styles.previewLabel}>Front</Text>
+                      <Text style={styles.previewPlaceholder}>Preview</Text>
+                    </View>
+                    <View style={styles.previewBlock}>
+                      <Text style={styles.previewLabel}>Back</Text>
+                      <Text style={styles.previewPlaceholder}>Preview</Text>
+                    </View>
+                    <View style={styles.previewBlock}>
+                      <Text style={styles.previewLabel}>Crest</Text>
+                      <Text style={styles.previewPlaceholder}>Vector</Text>
+                    </View>
+                  </View>
+                  <Text style={styles.helperCopy}>Layer control</Text>
+                  {concept.layers.map((layer) => (
+                    <Text key={layer.id} style={styles.layerRow}>
+                      {layer.editable ? '🖌️' : '🔒'} {layer.label}
+                    </Text>
+                  ))}
+                  <TouchableOpacity
+                    style={styles.secondaryButton}
+                    onPress={() => dispatch(exportConceptToCanva({ projectId: project.id, conceptId: concept.id }))}
+                  >
+                    <Text style={styles.secondaryButtonText}>Open in Canva</Text>
+                  </TouchableOpacity>
+                  <TouchableOpacity
+                    style={styles.secondaryButton}
+                    onPress={() => dispatch(syncCanvaRevision({ projectId: project.id, conceptId: concept.id }))}
+                  >
+                    <Text style={styles.secondaryButtonText}>Sync Canva revision</Text>
+                  </TouchableOpacity>
+
+                  <View style={styles.feedbackSection}>
+                    <Text style={styles.feedbackTitle}>Feedback & tasks</Text>
+                    {concept.feedback.map((feedback) => (
+                      <Text key={feedback.id} style={styles.feedbackItem}>
+                        {feedback.author}: {feedback.message}
+                      </Text>
+                    ))}
+                    <TextInput
+                      value={feedbackDraft}
+                      onChangeText={(text) =>
+                        setFeedbackDrafts((current) => ({
+                          ...current,
+                          [concept.id]: text,
+                        }))
+                      }
+                      style={[styles.input, styles.multilineInput]}
+                      placeholder="Add feedback for the team"
+                      multiline
+                    />
+                    <TouchableOpacity
+                      style={styles.secondaryButton}
+                      onPress={() => {
+                        if (!feedbackDraft.trim()) {
+                          return;
+                        }
+                        dispatch(
+                          addConceptFeedback({
+                            projectId: project.id,
+                            conceptId: concept.id,
+                            author: 'Captain',
+                            message: feedbackDraft.trim(),
+                          }),
+                        );
+                        setFeedbackDrafts((current) => ({ ...current, [concept.id]: '' }));
+                      }}
+                    >
+                      <Text style={styles.secondaryButtonText}>Share feedback</Text>
+                    </TouchableOpacity>
+                    {concept.tasks.map((task) => (
+                      <TouchableOpacity
+                        key={task.id}
+                        style={[styles.taskChip, task.status === 'completed' && styles.taskChipCompleted]}
+                        onPress={() =>
+                          dispatch(
+                            updateConceptTaskStatus({
+                              projectId: project.id,
+                              conceptId: concept.id,
+                              taskId: task.id,
+                              status: task.status === 'completed' ? 'open' : 'completed',
+                            }),
+                          )
+                        }
+                      >
+                        <Text style={styles.taskChipText}>
+                          {task.status === 'completed' ? '✅' : '📝'} {task.summary}
+                        </Text>
+                      </TouchableOpacity>
+                    ))}
+                    <TextInput
+                      value={taskDraft}
+                      onChangeText={(text) =>
+                        setTaskDrafts((current) => ({
+                          ...current,
+                          [concept.id]: text,
+                        }))
+                      }
+                      style={styles.input}
+                      placeholder="Add task e.g. adjust collar"
+                    />
+                    <TouchableOpacity
+                      style={styles.secondaryButton}
+                      onPress={() => {
+                        if (!taskDraft.trim()) {
+                          return;
+                        }
+                        dispatch(
+                          addConceptTask({
+                            projectId: project.id,
+                            conceptId: concept.id,
+                            summary: taskDraft.trim(),
+                          }),
+                        );
+                        setTaskDrafts((current) => ({ ...current, [concept.id]: '' }));
+                      }}
+                    >
+                      <Text style={styles.secondaryButtonText}>Create task</Text>
+                    </TouchableOpacity>
+                  </View>
+
+                  <Text style={styles.helperCopy}>
+                    Voting tally: ✅ {votes.approve} • 🔁 {votes.revise}
+                  </Text>
+                  <View style={styles.voteRow}>
+                    <TouchableOpacity
+                      style={[styles.voteButton, voteChoice[concept.id] === 'approve' && styles.voteButtonActive]}
+                      onPress={() =>
+                        setVoteChoice((current) => ({
+                          ...current,
+                          [concept.id]: 'approve',
+                        }))
+                      }
+                    >
+                      <Text style={styles.voteButtonText}>Approve</Text>
+                    </TouchableOpacity>
+                    <TouchableOpacity
+                      style={[styles.voteButton, voteChoice[concept.id] === 'revise' && styles.voteButtonActive]}
+                      onPress={() =>
+                        setVoteChoice((current) => ({
+                          ...current,
+                          [concept.id]: 'revise',
+                        }))
+                      }
+                    >
+                      <Text style={styles.voteButtonText}>Request changes</Text>
+                    </TouchableOpacity>
+                    <TouchableOpacity
+                      style={styles.secondaryButton}
+                      onPress={() =>
+                        dispatch(
+                          castConceptVote({
+                            projectId: project.id,
+                            conceptId: concept.id,
+                            memberId: 'captain',
+                            vote: voteChoice[concept.id] ?? 'approve',
+                          }),
+                        )
+                      }
+                    >
+                      <Text style={styles.secondaryButtonText}>Submit vote</Text>
+                    </TouchableOpacity>
+                  </View>
+                </View>
+              );
+            })}
+          </View>
+
+          <Text style={styles.subheading}>Structured voting</Text>
+          <Text style={styles.helperCopy}>
+            Open a voting window and Football App will collect ballots, tally results, and lock in the winning concept.
+          </Text>
+          <View style={styles.votingRow}>
+            <TouchableOpacity
+              style={styles.secondaryButton}
+              onPress={() =>
+                dispatch(
+                  scheduleVotingWindow({
+                    projectId: project.id,
+                    opensAt: new Date().toISOString(),
+                    closesAt: new Date(Date.now() + 72 * 60 * 60 * 1000).toISOString(),
+                  }),
+                )
+              }
+            >
+              <Text style={styles.secondaryButtonText}>Start voting</Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              style={styles.secondaryButton}
+              onPress={() => dispatch(closeVotingWindow({ projectId: project.id }))}
+            >
+              <Text style={styles.secondaryButtonText}>Close voting</Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              style={styles.secondaryButton}
+              onPress={() => dispatch(createProductionPackage({ projectId: project.id }))}
+            >
+              <Text style={styles.secondaryButtonText}>Generate production files</Text>
+            </TouchableOpacity>
+          </View>
+          {project.votingWindow && (
+            <Text style={styles.helperCopy}>
+              Voting window • {new Date(project.votingWindow.opensAt).toLocaleString()} →{' '}
+              {new Date(project.votingWindow.closesAt).toLocaleString()}
+            </Text>
+          )}
+
+          <Text style={styles.subheading}>Vendor handoff</Text>
+          <View style={styles.vendorRow}>
+            {vendors.map((vendor) => (
+              <TouchableOpacity key={vendor.id} style={styles.vendorCard} onPress={() => handleRequestQuote(vendor.id)}>
+                <Text style={styles.vendorName}>{vendor.vendorName}</Text>
+                <Text style={styles.vendorMeta}>
+                  {vendor.currency} {vendor.unitPrice} / kit • MOQ {vendor.minimumOrder}
+                </Text>
+                <Text style={styles.vendorMeta}>Lead time: {vendor.leadTimeWeeks} weeks</Text>
+              </TouchableOpacity>
+            ))}
+          </View>
+          {project.vendorQuoteId && (
+            <TouchableOpacity style={styles.primaryButton} onPress={handleConfirmOrder}>
+              <Text style={styles.primaryButtonText}>Confirm order & collect payment</Text>
+            </TouchableOpacity>
+          )}
+          {project.order && (
+            <View style={styles.orderCard}>
+              <Text style={styles.orderTitle}>Order status: {project.order.status}</Text>
+              <Text style={styles.orderMeta}>Submitted: {project.order.submittedAt}</Text>
+              <Text style={styles.orderMeta}>Total due: {project.order.totalPrice} ({project.order.paymentMethod})</Text>
+              <TouchableOpacity
+                style={styles.secondaryButton}
+                onPress={() =>
+                  dispatch(
+                    publishFinalKit({
+                      projectId: project.id,
+                      showcaseUrl: `https://community.football.app/teams/${teamId}/kits/${project.id}`,
+                    }),
+                  )
+                }
+              >
+                <Text style={styles.secondaryButtonText}>Share to community</Text>
+              </TouchableOpacity>
+            </View>
+          )}
+
+          <Text style={styles.subheading}>Post-launch</Text>
+          <Text style={styles.helperCopy}>
+            Spotlight the finished kit on your team profile and unlock premium drops for supporters.
+          </Text>
+          <TouchableOpacity style={styles.secondaryButton} onPress={handlePublish}>
+            <Text style={styles.secondaryButtonText}>Publish to team profile</Text>
+          </TouchableOpacity>
+          <View style={styles.upsellRow}>
+            {project.monetisationUpsells.map((item) => (
+              <View key={item} style={styles.upsellPill}>
+                <Text style={styles.upsellText}>{item}</Text>
+              </View>
+            ))}
+          </View>
+        </View>
+      )}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    backgroundColor: '#fff',
+    borderRadius: 16,
+    padding: 16,
+    borderWidth: 1,
+    borderColor: '#e2e8f0',
+    gap: 16,
+  },
+  sectionTitle: {
+    fontSize: 20,
+    fontWeight: '700',
+  },
+  statusPill: {
+    alignSelf: 'flex-start',
+    backgroundColor: '#e0f2fe',
+    color: '#0369a1',
+    paddingHorizontal: 12,
+    paddingVertical: 4,
+    borderRadius: 999,
+    fontWeight: '600',
+  },
+  emptyState: {
+    gap: 12,
+  },
+  emptyTitle: {
+    fontSize: 18,
+    fontWeight: '600',
+  },
+  emptyCopy: {
+    color: '#475569',
+    lineHeight: 20,
+  },
+  briefGrid: {
+    flexDirection: 'row',
+    gap: 12,
+    flexWrap: 'wrap',
+  },
+  briefColumn: {
+    flex: 1,
+    gap: 8,
+    minWidth: 160,
+  },
+  inputLabel: {
+    fontWeight: '600',
+    color: '#1f2937',
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: '#cbd5f5',
+    borderRadius: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    backgroundColor: '#f8fafc',
+  },
+  multilineInput: {
+    minHeight: 60,
+    textAlignVertical: 'top',
+  },
+  anchorHelper: {
+    color: '#64748b',
+    fontSize: 12,
+  },
+  primaryButton: {
+    backgroundColor: '#2563eb',
+    borderRadius: 999,
+    paddingVertical: 12,
+    alignItems: 'center',
+    marginTop: 8,
+  },
+  primaryButtonText: {
+    color: '#fff',
+    fontWeight: '600',
+  },
+  secondaryButton: {
+    borderRadius: 999,
+    borderWidth: 1,
+    borderColor: '#2563eb',
+    paddingVertical: 8,
+    paddingHorizontal: 16,
+    alignItems: 'center',
+    alignSelf: 'flex-start',
+  },
+  secondaryButtonText: {
+    color: '#2563eb',
+    fontWeight: '600',
+  },
+  content: {
+    gap: 16,
+  },
+  subheading: {
+    fontSize: 16,
+    fontWeight: '700',
+    marginTop: 8,
+  },
+  helperCopy: {
+    color: '#475569',
+    lineHeight: 18,
+  },
+  promptRow: {
+    flexGrow: 0,
+  },
+  promptCard: {
+    width: 200,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: '#cbd5f5',
+    padding: 12,
+    marginRight: 12,
+    backgroundColor: '#fff',
+  },
+  promptCardSelected: {
+    borderColor: '#2563eb',
+    backgroundColor: '#eff6ff',
+  },
+  promptTitle: {
+    fontWeight: '700',
+    marginBottom: 4,
+  },
+  promptCopy: {
+    color: '#475569',
+    fontSize: 12,
+  },
+  templateRow: {
+    flexGrow: 0,
+  },
+  templateCard: {
+    width: 160,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: '#cbd5f5',
+    padding: 12,
+    marginRight: 12,
+    gap: 8,
+  },
+  templatePreview: {
+    backgroundColor: '#111827',
+    borderRadius: 12,
+    padding: 12,
+    minHeight: 80,
+    justifyContent: 'center',
+  },
+  templatePreviewText: {
+    color: '#f8fafc',
+    fontWeight: '600',
+  },
+  templateCategory: {
+    fontSize: 12,
+    color: '#64748b',
+  },
+  templateLink: {
+    fontSize: 12,
+    color: '#2563eb',
+    fontWeight: '600',
+  },
+  conceptsGrid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 12,
+  },
+  conceptCard: {
+    flexBasis: '48%',
+    minWidth: 280,
+    borderRadius: 16,
+    borderWidth: 1,
+    borderColor: '#cbd5f5',
+    padding: 12,
+    gap: 8,
+    backgroundColor: '#fff',
+  },
+  conceptTitle: {
+    fontSize: 16,
+    fontWeight: '700',
+  },
+  conceptMeta: {
+    color: '#64748b',
+    fontSize: 12,
+  },
+  previewRow: {
+    flexDirection: 'row',
+    gap: 8,
+  },
+  previewBlock: {
+    flex: 1,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: '#e2e8f0',
+    alignItems: 'center',
+    paddingVertical: 16,
+    gap: 8,
+  },
+  previewLabel: {
+    fontWeight: '600',
+  },
+  previewPlaceholder: {
+    color: '#94a3b8',
+  },
+  layerRow: {
+    color: '#1f2937',
+  },
+  feedbackSection: {
+    gap: 8,
+  },
+  feedbackTitle: {
+    fontWeight: '700',
+  },
+  feedbackItem: {
+    fontSize: 12,
+    color: '#475569',
+  },
+  taskChip: {
+    backgroundColor: '#f8fafc',
+    borderRadius: 999,
+    paddingVertical: 6,
+    paddingHorizontal: 12,
+    borderWidth: 1,
+    borderColor: '#cbd5f5',
+    alignSelf: 'flex-start',
+  },
+  taskChipCompleted: {
+    backgroundColor: '#dcfce7',
+    borderColor: '#15803d',
+  },
+  taskChipText: {
+    color: '#1f2937',
+    fontWeight: '600',
+  },
+  voteRow: {
+    flexDirection: 'row',
+    gap: 8,
+    flexWrap: 'wrap',
+  },
+  voteButton: {
+    borderRadius: 999,
+    borderWidth: 1,
+    borderColor: '#e2e8f0',
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+  },
+  voteButtonActive: {
+    borderColor: '#2563eb',
+    backgroundColor: '#eff6ff',
+  },
+  voteButtonText: {
+    fontWeight: '600',
+  },
+  votingRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 12,
+  },
+  vendorRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 12,
+  },
+  vendorCard: {
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: '#cbd5f5',
+    padding: 12,
+    minWidth: 200,
+    backgroundColor: '#f8fafc',
+  },
+  vendorName: {
+    fontWeight: '700',
+  },
+  vendorMeta: {
+    color: '#475569',
+    fontSize: 12,
+  },
+  orderCard: {
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: '#22c55e',
+    backgroundColor: '#f0fdf4',
+    padding: 12,
+    gap: 4,
+  },
+  orderTitle: {
+    fontWeight: '700',
+    color: '#166534',
+  },
+  orderMeta: {
+    fontSize: 12,
+    color: '#15803d',
+  },
+  upsellRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 8,
+  },
+  upsellPill: {
+    borderRadius: 999,
+    backgroundColor: '#fdf4ff',
+    borderWidth: 1,
+    borderColor: '#f0abfc',
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+  },
+  upsellText: {
+    color: '#86198f',
+    fontWeight: '600',
+  },
+});
+
+export default KitDesignBoard;

--- a/football-app/src/components/TeamChatPanel.tsx
+++ b/football-app/src/components/TeamChatPanel.tsx
@@ -1,0 +1,400 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { View, Text, StyleSheet, TextInput, TouchableOpacity, ScrollView } from 'react-native';
+
+import { useAppDispatch, useAppSelector } from '../store/hooks';
+import {
+  cacheRecentMessages,
+  closePoll,
+  createContextualThread,
+  createPoll,
+  markThreadResolved,
+  muteThread,
+  pinMessage,
+  postMessage,
+  selectThreadsByTeam,
+  setRealtimeBackend,
+  setRealtimeConnection,
+  voteOnPoll,
+} from '../store/slices/teamChatSlice';
+import { selectKitProjectsByTeam } from '../store/slices/kitDesignSlice';
+
+interface TeamChatPanelProps {
+  teamId: string;
+}
+
+const TeamChatPanel: React.FC<TeamChatPanelProps> = ({ teamId }) => {
+  const dispatch = useAppDispatch();
+  const threads = useAppSelector((state) => selectThreadsByTeam(state, teamId));
+  const chatState = useAppSelector((state) => state.teamChat);
+  const kitProjects = useAppSelector((state) => selectKitProjectsByTeam(state, teamId));
+  const kitThread = useMemo(() => threads.find((thread) => thread.type === 'kit'), [threads]);
+  const matchdayThread = useMemo(
+    () => threads.find((thread) => thread.type === 'matchday'),
+    [threads],
+  );
+  const announcementThread = useMemo(
+    () => threads.find((thread) => thread.type === 'announcement'),
+    [threads],
+  );
+
+  const [messageDrafts, setMessageDrafts] = useState<Record<string, string>>({});
+  const [pollQuestion, setPollQuestion] = useState('');
+  const [pollOptions, setPollOptions] = useState('Yes,No');
+
+  useEffect(() => {
+    if (!kitThread && kitProjects.length > 0) {
+      dispatch(
+        createContextualThread({
+          teamId,
+          title: 'Kit Design Room',
+          type: 'kit',
+          createdBy: 'System',
+          metadata: { relatedKitProjectId: kitProjects[0].id },
+        }),
+      );
+    }
+  }, [kitThread, kitProjects, dispatch, teamId]);
+
+  useEffect(() => {
+    if (!matchdayThread) {
+      dispatch(
+        createContextualThread({
+          teamId,
+          title: 'Matchday Logistics',
+          type: 'matchday',
+          createdBy: 'System',
+        }),
+      );
+    }
+
+    if (!announcementThread) {
+      dispatch(
+        createContextualThread({
+          teamId,
+          title: 'Team Announcements',
+          type: 'announcement',
+          createdBy: 'System',
+        }),
+      );
+    }
+  }, [matchdayThread, announcementThread, dispatch, teamId]);
+
+  const handleSendMessage = (threadId: string) => {
+    const body = messageDrafts[threadId]?.trim();
+    if (!body) {
+      return;
+    }
+
+    dispatch(
+      postMessage({
+        threadId,
+        senderId: 'captain',
+        senderName: 'Captain',
+        body,
+      }),
+    );
+    setMessageDrafts((current) => ({ ...current, [threadId]: '' }));
+    dispatch(cacheRecentMessages({ threadId }));
+  };
+
+  const handleCreatePoll = (threadId: string) => {
+    if (!pollQuestion.trim()) {
+      return;
+    }
+
+    const options = pollOptions
+      .split(',')
+      .map((option) => option.trim())
+      .filter(Boolean);
+
+    if (options.length < 2) {
+      return;
+    }
+
+    dispatch(
+      createPoll({
+        threadId,
+        question: pollQuestion.trim(),
+        options,
+        closesAt: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
+      }),
+    );
+    setPollQuestion('');
+    setPollOptions('Yes,No');
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.sectionTitle}>Team live chat</Text>
+      <View style={styles.statusRow}>
+        <Text style={styles.statusBadge}>{chatState.backend.toUpperCase()} real-time</Text>
+        <Text style={styles.statusCopy}>{chatState.connected ? 'Connected' : 'Offline mode'}</Text>
+        <TouchableOpacity
+          style={styles.secondaryButton}
+          onPress={() =>
+            dispatch(
+              setRealtimeConnection({
+                connected: !chatState.connected,
+              }),
+            )
+          }
+        >
+          <Text style={styles.secondaryButtonText}>{chatState.connected ? 'Go offline' : 'Reconnect'}</Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          style={styles.secondaryButton}
+          onPress={() =>
+            dispatch(
+              setRealtimeBackend({
+                backend: chatState.backend === 'firebase' ? 'stream' : 'firebase',
+              }),
+            )
+          }
+        >
+          <Text style={styles.secondaryButtonText}>Switch backend</Text>
+        </TouchableOpacity>
+      </View>
+      <ScrollView horizontal showsHorizontalScrollIndicator={false} style={styles.threadRow}>
+        {threads.map((thread) => (
+          <View key={thread.id} style={styles.threadCard}>
+            <Text style={styles.threadTitle}>{thread.title}</Text>
+            <Text style={styles.threadMeta}>
+              Last activity {new Date(thread.lastActivityAt).toLocaleTimeString()} • {thread.messages.length} messages
+            </Text>
+            <ScrollView style={styles.messageList}>
+              {thread.messages.slice(-4).map((message) => (
+                <TouchableOpacity
+                  key={message.id}
+                  style={styles.messageBubble}
+                  onLongPress={() => dispatch(pinMessage({ threadId: thread.id, messageId: message.id }))}
+                >
+                  <Text style={styles.messageAuthor}>{message.senderName}</Text>
+                  <Text style={styles.messageBody}>{message.body}</Text>
+                </TouchableOpacity>
+              ))}
+            </ScrollView>
+            <TextInput
+              value={messageDrafts[thread.id] ?? ''}
+              onChangeText={(text) =>
+                setMessageDrafts((current) => ({
+                  ...current,
+                  [thread.id]: text,
+                }))
+              }
+              style={styles.input}
+              placeholder="Share an update"
+            />
+            <View style={styles.threadActions}>
+              <TouchableOpacity style={styles.primaryButton} onPress={() => handleSendMessage(thread.id)}>
+                <Text style={styles.primaryButtonText}>Send</Text>
+              </TouchableOpacity>
+              <TouchableOpacity
+                style={styles.secondaryButton}
+                onPress={() => dispatch(muteThread({ threadId: thread.id, muted: !thread.muted }))}
+              >
+                <Text style={styles.secondaryButtonText}>{thread.muted ? 'Unmute' : 'Mute'}</Text>
+              </TouchableOpacity>
+              <TouchableOpacity
+                style={styles.secondaryButton}
+                onPress={() => dispatch(markThreadResolved({ threadId: thread.id, resolved: !thread.resolved }))}
+              >
+                <Text style={styles.secondaryButtonText}>{thread.resolved ? 'Reopen' : 'Mark resolved'}</Text>
+              </TouchableOpacity>
+            </View>
+            {thread.polls.map((poll) => (
+              <View key={poll.id} style={styles.pollCard}>
+                <Text style={styles.pollQuestion}>{poll.question}</Text>
+                {poll.options.map((option) => (
+                  <TouchableOpacity
+                    key={option.id}
+                    style={styles.pollOption}
+                    onPress={() =>
+                      dispatch(
+                        voteOnPoll({
+                          threadId: thread.id,
+                          pollId: poll.id,
+                          optionId: option.id,
+                          memberId: 'captain',
+                        }),
+                      )
+                    }
+                  >
+                    <Text style={styles.pollOptionLabel}>
+                      {option.label} ({option.votes.length})
+                    </Text>
+                  </TouchableOpacity>
+                ))}
+                <TouchableOpacity style={styles.secondaryButton} onPress={() => dispatch(closePoll({ threadId: thread.id, pollId: poll.id }))}>
+                  <Text style={styles.secondaryButtonText}>{poll.closed ? 'Closed' : 'Close poll'}</Text>
+                </TouchableOpacity>
+              </View>
+            ))}
+            <TouchableOpacity
+              style={styles.secondaryButton}
+              onPress={() => handleCreatePoll(thread.id)}
+            >
+              <Text style={styles.secondaryButtonText}>Create poll</Text>
+            </TouchableOpacity>
+          </View>
+        ))}
+      </ScrollView>
+      <View style={styles.pollComposer}>
+        <Text style={styles.subheading}>Quick poll</Text>
+        <TextInput
+          value={pollQuestion}
+          onChangeText={setPollQuestion}
+          style={styles.input}
+          placeholder="Question e.g. Approve Concept 3?"
+        />
+        <TextInput
+          value={pollOptions}
+          onChangeText={setPollOptions}
+          style={styles.input}
+          placeholder="Options separated by commas"
+        />
+      </View>
+      <Text style={styles.helperCopy}>
+        Cached conversations: {chatState.cached.length} threads • Offline queue {chatState.offlineQueue.length} messages
+      </Text>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    backgroundColor: '#fff',
+    borderRadius: 16,
+    padding: 16,
+    borderWidth: 1,
+    borderColor: '#e2e8f0',
+    gap: 16,
+  },
+  sectionTitle: {
+    fontSize: 20,
+    fontWeight: '700',
+  },
+  statusRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 12,
+    alignItems: 'center',
+  },
+  statusBadge: {
+    paddingHorizontal: 10,
+    paddingVertical: 4,
+    borderRadius: 999,
+    backgroundColor: '#eef2ff',
+    color: '#3730a3',
+    fontWeight: '600',
+  },
+  statusCopy: {
+    color: '#475569',
+    fontSize: 12,
+  },
+  threadRow: {
+    flexGrow: 0,
+  },
+  threadCard: {
+    width: 240,
+    borderRadius: 16,
+    borderWidth: 1,
+    borderColor: '#cbd5f5',
+    padding: 12,
+    marginRight: 12,
+    gap: 12,
+    backgroundColor: '#f8fafc',
+  },
+  threadTitle: {
+    fontWeight: '700',
+  },
+  threadMeta: {
+    color: '#475569',
+    fontSize: 12,
+  },
+  messageList: {
+    maxHeight: 120,
+  },
+  messageBubble: {
+    backgroundColor: '#fff',
+    borderRadius: 12,
+    padding: 8,
+    marginBottom: 8,
+    borderWidth: 1,
+    borderColor: '#e2e8f0',
+  },
+  messageAuthor: {
+    fontWeight: '600',
+  },
+  messageBody: {
+    color: '#1f2937',
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: '#cbd5f5',
+    borderRadius: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    backgroundColor: '#fff',
+  },
+  threadActions: {
+    flexDirection: 'row',
+    gap: 8,
+    flexWrap: 'wrap',
+  },
+  primaryButton: {
+    backgroundColor: '#2563eb',
+    borderRadius: 999,
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+  },
+  primaryButtonText: {
+    color: '#fff',
+    fontWeight: '600',
+  },
+  secondaryButton: {
+    borderRadius: 999,
+    borderWidth: 1,
+    borderColor: '#2563eb',
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+    alignItems: 'center',
+  },
+  secondaryButtonText: {
+    color: '#2563eb',
+    fontWeight: '600',
+  },
+  pollCard: {
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: '#bae6fd',
+    backgroundColor: '#e0f2fe',
+    padding: 12,
+    gap: 8,
+  },
+  pollQuestion: {
+    fontWeight: '700',
+  },
+  pollOption: {
+    borderRadius: 999,
+    borderWidth: 1,
+    borderColor: '#0284c7',
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+  },
+  pollOptionLabel: {
+    color: '#0369a1',
+    fontWeight: '600',
+  },
+  pollComposer: {
+    gap: 8,
+  },
+  subheading: {
+    fontSize: 16,
+    fontWeight: '700',
+  },
+  helperCopy: {
+    color: '#475569',
+  },
+});
+
+export default TeamChatPanel;

--- a/football-app/src/screens/ManageTeamScreen.tsx
+++ b/football-app/src/screens/ManageTeamScreen.tsx
@@ -26,6 +26,8 @@ import {
 } from '../store/slices/teamsSlice';
 import AuthenticatedScreenContainer from '../components/AuthenticatedScreenContainer';
 import PitchFormation from '../components/PitchFormation';
+import KitDesignBoard from '../components/KitDesignBoard';
+import TeamChatPanel from '../components/TeamChatPanel';
 import {
   acceptFixtureKickoff,
   formatKickoffTime,
@@ -1313,6 +1315,24 @@ const ManageTeamScreen: React.FC = () => {
                 })
             )}
           </View>
+        </View>
+
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>Kit identity</Text>
+          <Text style={styles.sectionSubtitle}>
+            Spin up AI-powered designs, collect structured feedback, and hand off final assets to production without
+            leaving the app.
+          </Text>
+          <KitDesignBoard teamId={teamId} teamName={team.name} />
+        </View>
+
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>Live chat control room</Text>
+          <Text style={styles.sectionSubtitle}>
+            Keep design debates, matchday logistics, and squad-wide announcements organised with contextual threads and
+            polls.
+          </Text>
+          <TeamChatPanel teamId={teamId} />
         </View>
 
         <View style={styles.section}>

--- a/football-app/src/store/index.ts
+++ b/football-app/src/store/index.ts
@@ -14,6 +14,8 @@ import transferMarketReducer from './slices/transferMarketSlice';
 import playerDevelopmentReducer from './slices/playerDevelopmentSlice';
 import communityReducer from './slices/communitySlice';
 import mediaReducer from './slices/mediaSlice';
+import kitDesignReducer from './slices/kitDesignSlice';
+import teamChatReducer from './slices/teamChatSlice';
 import { authReducer } from './slices/authSlice';
 import { adminReducer } from './slices/adminSlice';
 
@@ -35,6 +37,8 @@ export const store = configureStore({
     playerDevelopment: playerDevelopmentReducer,
     community: communityReducer,
     media: mediaReducer,
+    kitDesign: kitDesignReducer,
+    teamChat: teamChatReducer,
 
   },
 });

--- a/football-app/src/store/slices/kitDesignSlice.ts
+++ b/football-app/src/store/slices/kitDesignSlice.ts
@@ -1,0 +1,754 @@
+import { createSlice, nanoid, PayloadAction } from '@reduxjs/toolkit';
+
+export type KitBrief = {
+  primaryColor: string;
+  secondaryColor: string;
+  sponsor: string;
+  vibe: string;
+  inspirationNotes?: string;
+  culturalAnchors: string[];
+};
+
+export type KitPrompt = {
+  id: string;
+  title: string;
+  description: string;
+  prompt: string;
+};
+
+export type CanvaTemplate = {
+  id: string;
+  title: string;
+  category: string;
+  thumbnailUrl: string;
+  templateUrl: string;
+};
+
+export type ConceptLayer = {
+  id: string;
+  label: string;
+  editable: boolean;
+};
+
+export type KitConcept = {
+  id: string;
+  title: string;
+  version: number;
+  generatedAt: string;
+  createdBy: 'ai' | 'canva';
+  frontPreviewUrl: string;
+  backPreviewUrl: string;
+  crestPreviewUrl: string;
+  layers: ConceptLayer[];
+  exportedToCanva?: {
+    designId: string;
+    exportedAt: string;
+    status: 'synced' | 'pending';
+  };
+  syncedFromCanvaAt?: string;
+  tasks: KitTask[];
+  feedback: KitFeedback[];
+  votes: KitVote[];
+  status: 'draft' | 'review' | 'approved' | 'archived';
+};
+
+export type KitTask = {
+  id: string;
+  summary: string;
+  status: 'open' | 'inProgress' | 'completed';
+  assignee?: string;
+};
+
+export type KitFeedback = {
+  id: string;
+  author: string;
+  message: string;
+  createdAt: string;
+  resolved: boolean;
+};
+
+export type KitVote = {
+  id: string;
+  memberId: string;
+  vote: 'approve' | 'revise';
+  castAt: string;
+};
+
+export type VotingWindow = {
+  opensAt: string;
+  closesAt: string;
+  result?: {
+    winningConceptId: string | null;
+    approved: boolean;
+  };
+};
+
+export type ProductionAsset = {
+  id: string;
+  type: 'vector' | 'mockup' | 'specSheet';
+  fileName: string;
+  downloadUrl: string;
+};
+
+export type VendorQuote = {
+  id: string;
+  vendorName: string;
+  region: string;
+  currency: string;
+  unitPrice: number;
+  minimumOrder: number;
+  leadTimeWeeks: number;
+  sizeRuns: string[];
+};
+
+export type KitOrderStatus = 'draft' | 'quoted' | 'submitted' | 'inProduction' | 'fulfilled' | 'shipped';
+
+export type KitOrder = {
+  id: string;
+  vendorId: string;
+  quoteId: string;
+  status: KitOrderStatus;
+  quantities: Record<string, number>;
+  totalPrice: number;
+  paymentMethod: 'wallet' | 'card';
+  submittedAt?: string;
+  updatedAt: string;
+  trackingUrl?: string;
+};
+
+export type KitProjectStage =
+  | 'brief'
+  | 'concepting'
+  | 'voting'
+  | 'finalReview'
+  | 'approved'
+  | 'production'
+  | 'complete';
+
+export type KitProject = {
+  id: string;
+  teamId: string;
+  title: string;
+  createdAt: string;
+  updatedAt: string;
+  brief: KitBrief;
+  prompts: KitPrompt[];
+  concepts: KitConcept[];
+  activeConceptId: string | null;
+  stage: KitProjectStage;
+  votingWindow?: VotingWindow;
+  productionAssets: ProductionAsset[];
+  vendorQuoteId?: string;
+  order?: KitOrder;
+  showcaseUrl?: string;
+  monetisationUpsells: string[];
+  chatThreadId?: string;
+};
+
+export type KitDesignState = {
+  projects: KitProject[];
+  promptLibrary: KitPrompt[];
+  canvaTemplates: CanvaTemplate[];
+  vendorCatalog: VendorQuote[];
+};
+
+const defaultPromptLibrary: KitPrompt[] = [
+  {
+    id: 'heritage-river',
+    title: 'River heritage',
+    description: 'Highlight the waterways that define your city with flowing pinstripes.',
+    prompt:
+      'Design a home kit inspired by the city river. Use gradient blues, reflective silver trims, and a crest that nods to maritime history.',
+  },
+  {
+    id: 'industrial-roots',
+    title: 'Industrial roots',
+    description: 'Lean into bold angles and metallic accents from local factories.',
+    prompt:
+      'Create a bold jersey that celebrates industrial heritage. Dark charcoal base, copper piping, angular sponsor lockup referencing steel beams.',
+  },
+  {
+    id: 'youth-academy',
+    title: 'Academy revival',
+    description: 'Blend past academy kits with current colours for a unifying look.',
+    prompt:
+      'Fuse the 2004 academy sash with modern colour blocking. Include a sleeve badge celebrating youth graduates.',
+  },
+];
+
+const defaultCanvaTemplates: CanvaTemplate[] = [
+  {
+    id: 'canva-classic-001',
+    title: 'Classic Hoops',
+    category: 'Jersey Fronts',
+    thumbnailUrl: 'https://images.football.app/canva/hoops.png',
+    templateUrl: 'https://www.canva.com/design/kit-classic-hoops',
+  },
+  {
+    id: 'canva-badge-112',
+    title: 'Modern Crest Grid',
+    category: 'Crest',
+    thumbnailUrl: 'https://images.football.app/canva/crest-grid.png',
+    templateUrl: 'https://www.canva.com/design/crest-modern-grid',
+  },
+  {
+    id: 'canva-away-204',
+    title: 'Minimal Away Fade',
+    category: 'Jersey Backs',
+    thumbnailUrl: 'https://images.football.app/canva/away-fade.png',
+    templateUrl: 'https://www.canva.com/design/kit-minimal-away',
+  },
+];
+
+const defaultVendorCatalog: VendorQuote[] = [
+  {
+    id: 'vendor-print-lab',
+    vendorName: 'PrintLab Athletics',
+    region: 'EU',
+    currency: 'EUR',
+    unitPrice: 45,
+    minimumOrder: 12,
+    leadTimeWeeks: 4,
+    sizeRuns: ['XS-2XL', 'Custom goalkeeper cut'],
+  },
+  {
+    id: 'vendor-squad-supply',
+    vendorName: 'Squad Supply Co.',
+    region: 'US',
+    currency: 'USD',
+    unitPrice: 52,
+    minimumOrder: 10,
+    leadTimeWeeks: 5,
+    sizeRuns: ['Youth S-L', 'Adult XS-4XL'],
+  },
+  {
+    id: 'vendor-kit-forge',
+    vendorName: 'Kit Forge',
+    region: 'APAC',
+    currency: 'USD',
+    unitPrice: 48,
+    minimumOrder: 15,
+    leadTimeWeeks: 6,
+    sizeRuns: ['Unisex XS-3XL'],
+  },
+];
+
+const initialState: KitDesignState = {
+  projects: [],
+  promptLibrary: defaultPromptLibrary,
+  canvaTemplates: defaultCanvaTemplates,
+  vendorCatalog: defaultVendorCatalog,
+};
+
+const updateProjectTimestamp = (project: KitProject) => {
+  project.updatedAt = new Date().toISOString();
+};
+
+const findProject = (state: KitDesignState, projectId: string) =>
+  state.projects.find((candidate) => candidate.id === projectId);
+
+const kitDesignSlice = createSlice({
+  name: 'kitDesign',
+  initialState,
+  reducers: {
+    startKitProject: (
+      state,
+      action: PayloadAction<{ teamId: string; title: string; brief?: Partial<KitBrief>; chatThreadId?: string }>,
+    ) => {
+      const { teamId, title, brief, chatThreadId } = action.payload;
+      const project: KitProject = {
+        id: nanoid(),
+        teamId,
+        title,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        brief: {
+          primaryColor: '#0f172a',
+          secondaryColor: '#facc15',
+          sponsor: 'Local Sponsor',
+          vibe: 'Bold + community-first',
+          inspirationNotes: '',
+          culturalAnchors: ['Club crest evolution', 'Local landmark'],
+          ...(brief ?? {}),
+        },
+        prompts: state.promptLibrary.slice(0, 2),
+        concepts: [],
+        activeConceptId: null,
+        stage: 'brief',
+        productionAssets: [],
+        monetisationUpsells: ['Alternate kit drop', 'Supporter patch pre-order'],
+        chatThreadId,
+      };
+
+      state.projects.push(project);
+    },
+    updateKitBrief: (
+      state,
+      action: PayloadAction<{ projectId: string; brief: Partial<KitBrief>; promptIds?: string[] }>,
+    ) => {
+      const { projectId, brief, promptIds } = action.payload;
+      const project = findProject(state, projectId);
+      if (!project) {
+        return;
+      }
+
+      project.brief = {
+        ...project.brief,
+        ...brief,
+      };
+
+      if (promptIds && promptIds.length > 0) {
+        project.prompts = state.promptLibrary.filter((prompt) => promptIds.includes(prompt.id));
+      }
+
+      updateProjectTimestamp(project);
+    },
+    addCustomPrompt: (
+      state,
+      action: PayloadAction<{ projectId: string; prompt: KitPrompt }>,
+    ) => {
+      const { projectId, prompt } = action.payload;
+      const project = findProject(state, projectId);
+      if (!project) {
+        return;
+      }
+
+      project.prompts = [...project.prompts, prompt];
+      updateProjectTimestamp(project);
+    },
+    generateAIConcepts: (
+      state,
+      action: PayloadAction<{ projectId: string; count?: number }>,
+    ) => {
+      const { projectId, count = 3 } = action.payload;
+      const project = findProject(state, projectId);
+      if (!project) {
+        return;
+      }
+
+      const generatedConcepts: KitConcept[] = Array.from({ length: count }).map((_, index) => {
+        const version = project.concepts.length + index + 1;
+        return {
+          id: nanoid(),
+          title: `Concept ${version}`,
+          version,
+          generatedAt: new Date().toISOString(),
+          createdBy: 'ai',
+          frontPreviewUrl: `https://images.football.app/kits/${projectId}/concept-${version}-front.png`,
+          backPreviewUrl: `https://images.football.app/kits/${projectId}/concept-${version}-back.png`,
+          crestPreviewUrl: `https://images.football.app/kits/${projectId}/concept-${version}-crest.png`,
+          layers: [
+            { id: nanoid(), label: 'Base pattern', editable: true },
+            { id: nanoid(), label: 'Accent stripes', editable: true },
+            { id: nanoid(), label: 'Sponsor lockup', editable: true },
+          ],
+          tasks: [],
+          feedback: [],
+          votes: [],
+          status: 'draft',
+        };
+      });
+
+      project.concepts = [...project.concepts, ...generatedConcepts];
+      project.activeConceptId = generatedConcepts[0]?.id ?? project.activeConceptId;
+      project.stage = 'concepting';
+      updateProjectTimestamp(project);
+    },
+    exportConceptToCanva: (
+      state,
+      action: PayloadAction<{ projectId: string; conceptId: string; designId?: string }>,
+    ) => {
+      const { projectId, conceptId, designId } = action.payload;
+      const project = findProject(state, projectId);
+      if (!project) {
+        return;
+      }
+
+      const concept = project.concepts.find((candidate) => candidate.id === conceptId);
+      if (!concept) {
+        return;
+      }
+
+      concept.exportedToCanva = {
+        designId: designId ?? `canva-${concept.id}`,
+        exportedAt: new Date().toISOString(),
+        status: 'pending',
+      };
+
+      concept.createdBy = 'canva';
+      updateProjectTimestamp(project);
+    },
+    syncCanvaRevision: (
+      state,
+      action: PayloadAction<{ projectId: string; conceptId: string; updatedLayers?: string[] }>,
+    ) => {
+      const { projectId, conceptId, updatedLayers } = action.payload;
+      const project = findProject(state, projectId);
+      if (!project) {
+        return;
+      }
+
+      const concept = project.concepts.find((candidate) => candidate.id === conceptId);
+      if (!concept) {
+        return;
+      }
+
+      concept.syncedFromCanvaAt = new Date().toISOString();
+      if (concept.exportedToCanva) {
+        concept.exportedToCanva.status = 'synced';
+      }
+
+      if (updatedLayers && updatedLayers.length > 0) {
+        concept.layers = concept.layers.map((layer, index) => ({
+          ...layer,
+          label: updatedLayers[index] ?? layer.label,
+        }));
+      }
+
+      updateProjectTimestamp(project);
+    },
+    addConceptTask: (
+      state,
+      action: PayloadAction<{ projectId: string; conceptId: string; summary: string; assignee?: string }>,
+    ) => {
+      const { projectId, conceptId, summary, assignee } = action.payload;
+      const project = findProject(state, projectId);
+      if (!project) {
+        return;
+      }
+
+      const concept = project.concepts.find((candidate) => candidate.id === conceptId);
+      if (!concept) {
+        return;
+      }
+
+      concept.tasks.push({
+        id: nanoid(),
+        summary,
+        status: 'open',
+        assignee,
+      });
+      updateProjectTimestamp(project);
+    },
+    updateConceptTaskStatus: (
+      state,
+      action: PayloadAction<{ projectId: string; conceptId: string; taskId: string; status: KitTask['status'] }>,
+    ) => {
+      const { projectId, conceptId, taskId, status } = action.payload;
+      const project = findProject(state, projectId);
+      if (!project) {
+        return;
+      }
+
+      const concept = project.concepts.find((candidate) => candidate.id === conceptId);
+      if (!concept) {
+        return;
+      }
+
+      const task = concept.tasks.find((candidate) => candidate.id === taskId);
+      if (!task) {
+        return;
+      }
+
+      task.status = status;
+      updateProjectTimestamp(project);
+    },
+    addConceptFeedback: (
+      state,
+      action: PayloadAction<{ projectId: string; conceptId: string; author: string; message: string }>,
+    ) => {
+      const { projectId, conceptId, author, message } = action.payload;
+      const project = findProject(state, projectId);
+      if (!project) {
+        return;
+      }
+
+      const concept = project.concepts.find((candidate) => candidate.id === conceptId);
+      if (!concept) {
+        return;
+      }
+
+      concept.feedback.push({
+        id: nanoid(),
+        author,
+        message,
+        createdAt: new Date().toISOString(),
+        resolved: false,
+      });
+      updateProjectTimestamp(project);
+    },
+    resolveFeedback: (
+      state,
+      action: PayloadAction<{ projectId: string; conceptId: string; feedbackId: string; resolved: boolean }>,
+    ) => {
+      const { projectId, conceptId, feedbackId, resolved } = action.payload;
+      const project = findProject(state, projectId);
+      if (!project) {
+        return;
+      }
+
+      const concept = project.concepts.find((candidate) => candidate.id === conceptId);
+      if (!concept) {
+        return;
+      }
+
+      const feedback = concept.feedback.find((candidate) => candidate.id === feedbackId);
+      if (!feedback) {
+        return;
+      }
+
+      feedback.resolved = resolved;
+      updateProjectTimestamp(project);
+    },
+    scheduleVotingWindow: (
+      state,
+      action: PayloadAction<{ projectId: string; opensAt: string; closesAt: string }>,
+    ) => {
+      const { projectId, opensAt, closesAt } = action.payload;
+      const project = findProject(state, projectId);
+      if (!project) {
+        return;
+      }
+
+      project.votingWindow = {
+        opensAt,
+        closesAt,
+      };
+      project.stage = 'voting';
+      updateProjectTimestamp(project);
+    },
+    castConceptVote: (
+      state,
+      action: PayloadAction<{ projectId: string; conceptId: string; memberId: string; vote: KitVote['vote'] }>,
+    ) => {
+      const { projectId, conceptId, memberId, vote } = action.payload;
+      const project = findProject(state, projectId);
+      if (!project) {
+        return;
+      }
+
+      const concept = project.concepts.find((candidate) => candidate.id === conceptId);
+      if (!concept) {
+        return;
+      }
+
+      const existingVote = concept.votes.find((candidate) => candidate.memberId === memberId);
+      if (existingVote) {
+        existingVote.vote = vote;
+        existingVote.castAt = new Date().toISOString();
+      } else {
+        concept.votes.push({
+          id: nanoid(),
+          memberId,
+          vote,
+          castAt: new Date().toISOString(),
+        });
+      }
+      updateProjectTimestamp(project);
+    },
+    closeVotingWindow: (state, action: PayloadAction<{ projectId: string }>) => {
+      const { projectId } = action.payload;
+      const project = findProject(state, projectId);
+      if (!project || !project.votingWindow) {
+        return;
+      }
+
+      const approvalTallies = project.concepts.map((concept) => ({
+        conceptId: concept.id,
+        approvals: concept.votes.filter((vote) => vote.vote === 'approve').length,
+      }));
+
+      const winning = approvalTallies.sort((a, b) => b.approvals - a.approvals)[0];
+      project.votingWindow.result = {
+        winningConceptId: winning?.conceptId ?? null,
+        approved: (winning?.approvals ?? 0) > 0,
+      };
+
+      project.activeConceptId = winning?.conceptId ?? project.activeConceptId;
+      project.stage = 'finalReview';
+      updateProjectTimestamp(project);
+    },
+    approveConcept: (state, action: PayloadAction<{ projectId: string; conceptId: string }>) => {
+      const { projectId, conceptId } = action.payload;
+      const project = findProject(state, projectId);
+      if (!project) {
+        return;
+      }
+
+      const concept = project.concepts.find((candidate) => candidate.id === conceptId);
+      if (!concept) {
+        return;
+      }
+
+      concept.status = 'approved';
+      project.activeConceptId = conceptId;
+      project.stage = 'approved';
+      updateProjectTimestamp(project);
+    },
+    createProductionPackage: (state, action: PayloadAction<{ projectId: string }>) => {
+      const { projectId } = action.payload;
+      const project = findProject(state, projectId);
+      if (!project) {
+        return;
+      }
+
+      if (!project.activeConceptId) {
+        return;
+      }
+
+      project.productionAssets = [
+        {
+          id: nanoid(),
+          type: 'vector',
+          fileName: `${project.title.replace(/\s+/g, '-').toLowerCase()}-vector.ai`,
+          downloadUrl: `https://files.football.app/kits/${projectId}/vector.ai`,
+        },
+        {
+          id: nanoid(),
+          type: 'mockup',
+          fileName: `${project.title.replace(/\s+/g, '-').toLowerCase()}-mockup.png`,
+          downloadUrl: `https://files.football.app/kits/${projectId}/mockup.png`,
+        },
+        {
+          id: nanoid(),
+          type: 'specSheet',
+          fileName: `${project.title.replace(/\s+/g, '-').toLowerCase()}-spec.pdf`,
+          downloadUrl: `https://files.football.app/kits/${projectId}/spec.pdf`,
+        },
+      ];
+      project.stage = 'production';
+      updateProjectTimestamp(project);
+    },
+    requestVendorQuote: (
+      state,
+      action: PayloadAction<{ projectId: string; vendorId: string }>,
+    ) => {
+      const { projectId, vendorId } = action.payload;
+      const project = findProject(state, projectId);
+      if (!project) {
+        return;
+      }
+
+      project.vendorQuoteId = vendorId;
+      updateProjectTimestamp(project);
+    },
+    confirmKitOrder: (
+      state,
+      action: PayloadAction<{
+        projectId: string;
+        quoteId: string;
+        paymentMethod: KitOrder['paymentMethod'];
+        quantities: Record<string, number>;
+      }>,
+    ) => {
+      const { projectId, quoteId, paymentMethod, quantities } = action.payload;
+      const project = findProject(state, projectId);
+      if (!project) {
+        return;
+      }
+
+      const quote = state.vendorCatalog.find((candidate) => candidate.id === quoteId);
+      const totalUnits = Object.values(quantities).reduce((sum, value) => sum + value, 0);
+      const totalPrice = quote ? quote.unitPrice * totalUnits : totalUnits * 40;
+
+      project.order = {
+        id: nanoid(),
+        vendorId: quoteId,
+        quoteId,
+        status: 'submitted',
+        quantities,
+        totalPrice,
+        paymentMethod,
+        submittedAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      };
+
+      updateProjectTimestamp(project);
+    },
+    updateOrderStatus: (
+      state,
+      action: PayloadAction<{ projectId: string; status: KitOrderStatus; trackingUrl?: string }>,
+    ) => {
+      const { projectId, status, trackingUrl } = action.payload;
+      const project = findProject(state, projectId);
+      if (!project || !project.order) {
+        return;
+      }
+
+      project.order.status = status;
+      project.order.updatedAt = new Date().toISOString();
+      if (trackingUrl) {
+        project.order.trackingUrl = trackingUrl;
+      }
+
+      if (status === 'fulfilled' || status === 'shipped') {
+        project.stage = 'complete';
+      }
+
+      updateProjectTimestamp(project);
+    },
+    publishFinalKit: (
+      state,
+      action: PayloadAction<{ projectId: string; showcaseUrl: string }>,
+    ) => {
+      const { projectId, showcaseUrl } = action.payload;
+      const project = findProject(state, projectId);
+      if (!project) {
+        return;
+      }
+
+      project.showcaseUrl = showcaseUrl;
+      updateProjectTimestamp(project);
+    },
+    attachChatThread: (
+      state,
+      action: PayloadAction<{ projectId: string; threadId: string }>,
+    ) => {
+      const { projectId, threadId } = action.payload;
+      const project = findProject(state, projectId);
+      if (!project) {
+        return;
+      }
+
+      project.chatThreadId = threadId;
+      updateProjectTimestamp(project);
+    },
+  },
+});
+
+export const {
+  startKitProject,
+  updateKitBrief,
+  addCustomPrompt,
+  generateAIConcepts,
+  exportConceptToCanva,
+  syncCanvaRevision,
+  addConceptTask,
+  updateConceptTaskStatus,
+  addConceptFeedback,
+  resolveFeedback,
+  scheduleVotingWindow,
+  castConceptVote,
+  closeVotingWindow,
+  approveConcept,
+  createProductionPackage,
+  requestVendorQuote,
+  confirmKitOrder,
+  updateOrderStatus,
+  publishFinalKit,
+  attachChatThread,
+} = kitDesignSlice.actions;
+
+export const selectKitProjectsByTeam = (state: { kitDesign: KitDesignState }, teamId: string) =>
+  state.kitDesign.projects.filter((project) => project.teamId === teamId);
+
+export const selectCanvaTemplates = (state: { kitDesign: KitDesignState }) =>
+  state.kitDesign.canvaTemplates;
+
+export const selectKitPromptLibrary = (state: { kitDesign: KitDesignState }) =>
+  state.kitDesign.promptLibrary;
+
+export const selectVendorCatalog = (state: { kitDesign: KitDesignState }) =>
+  state.kitDesign.vendorCatalog;
+
+export default kitDesignSlice.reducer;

--- a/football-app/src/store/slices/teamChatSlice.ts
+++ b/football-app/src/store/slices/teamChatSlice.ts
@@ -1,0 +1,432 @@
+import { createSlice, nanoid, PayloadAction } from '@reduxjs/toolkit';
+
+export type ChatBackend = 'firebase' | 'stream' | 'appsync';
+
+export type ChatAttachment = {
+  id: string;
+  type: 'image' | 'file' | 'link';
+  url: string;
+  title?: string;
+};
+
+export type ChatReaction = {
+  id: string;
+  emoji: string;
+  memberId: string;
+  createdAt: string;
+};
+
+export type ChatPollOption = {
+  id: string;
+  label: string;
+  votes: string[];
+};
+
+export type ChatPoll = {
+  id: string;
+  question: string;
+  createdAt: string;
+  closesAt?: string;
+  options: ChatPollOption[];
+  closed: boolean;
+};
+
+export type ChatMessage = {
+  id: string;
+  threadId: string;
+  senderId: string;
+  senderName: string;
+  body: string;
+  createdAt: string;
+  replyToId?: string;
+  reactions: ChatReaction[];
+  attachments: ChatAttachment[];
+  pollId?: string;
+};
+
+export type ChatThreadType = 'kit' | 'matchday' | 'announcement' | 'direct';
+
+export type ChatThread = {
+  id: string;
+  teamId: string;
+  title: string;
+  type: ChatThreadType;
+  createdAt: string;
+  createdBy: string;
+  messages: ChatMessage[];
+  polls: ChatPoll[];
+  pinnedMessageIds: string[];
+  muted: boolean;
+  resolved: boolean;
+  metadata?: {
+    relatedKitProjectId?: string;
+    lastSupplierUpdate?: string;
+  };
+  lastActivityAt: string;
+};
+
+export type AuditLogEntry = {
+  id: string;
+  teamId: string;
+  actor: string;
+  action: string;
+  createdAt: string;
+  threadId?: string;
+  context?: Record<string, string>;
+};
+
+export type CachedThreadMessages = {
+  threadId: string;
+  cachedAt: string;
+  messages: ChatMessage[];
+};
+
+export type TeamChatState = {
+  backend: ChatBackend;
+  connected: boolean;
+  lastSyncedAt: string | null;
+  threads: ChatThread[];
+  cached: CachedThreadMessages[];
+  offlineQueue: ChatMessage[];
+  auditLog: AuditLogEntry[];
+};
+
+const initialState: TeamChatState = {
+  backend: 'firebase',
+  connected: true,
+  lastSyncedAt: null,
+  threads: [],
+  cached: [],
+  offlineQueue: [],
+  auditLog: [],
+};
+
+const findThread = (state: TeamChatState, threadId: string) =>
+  state.threads.find((thread) => thread.id === threadId);
+
+const teamChatSlice = createSlice({
+  name: 'teamChat',
+  initialState,
+  reducers: {
+    setRealtimeBackend: (state, action: PayloadAction<{ backend: ChatBackend }>) => {
+      state.backend = action.payload.backend;
+    },
+    setRealtimeConnection: (state, action: PayloadAction<{ connected: boolean }>) => {
+      state.connected = action.payload.connected;
+      state.lastSyncedAt = action.payload.connected ? new Date().toISOString() : state.lastSyncedAt;
+    },
+    createContextualThread: (
+      state,
+      action: PayloadAction<{ teamId: string; title: string; type: ChatThreadType; createdBy: string; metadata?: ChatThread['metadata'] }>,
+    ) => {
+      const { teamId, title, type, createdBy, metadata } = action.payload;
+      const existing = state.threads.find(
+        (thread) => thread.teamId === teamId && thread.type === type && thread.title === title,
+      );
+
+      if (existing) {
+        return;
+      }
+
+      const now = new Date().toISOString();
+      state.threads.push({
+        id: nanoid(),
+        teamId,
+        title,
+        type,
+        createdAt: now,
+        createdBy,
+        messages: [],
+        polls: [],
+        pinnedMessageIds: [],
+        muted: false,
+        resolved: false,
+        metadata,
+        lastActivityAt: now,
+      });
+    },
+    linkThreadMetadata: (
+      state,
+      action: PayloadAction<{ threadId: string; metadata: ChatThread['metadata'] }>,
+    ) => {
+      const { threadId, metadata } = action.payload;
+      const thread = findThread(state, threadId);
+      if (!thread) {
+        return;
+      }
+
+      thread.metadata = {
+        ...thread.metadata,
+        ...metadata,
+      };
+      thread.lastActivityAt = new Date().toISOString();
+    },
+    postMessage: (
+      state,
+      action: PayloadAction<{ threadId: string; senderId: string; senderName: string; body: string; replyToId?: string; attachments?: ChatAttachment[] }>,
+    ) => {
+      const { threadId, senderId, senderName, body, replyToId, attachments } = action.payload;
+      const thread = findThread(state, threadId);
+      if (!thread) {
+        return;
+      }
+
+      const message: ChatMessage = {
+        id: nanoid(),
+        threadId,
+        senderId,
+        senderName,
+        body,
+        createdAt: new Date().toISOString(),
+        replyToId,
+        attachments: attachments ?? [],
+        reactions: [],
+      };
+
+      if (!state.connected) {
+        state.offlineQueue.push(message);
+      }
+
+      thread.messages.push(message);
+      thread.lastActivityAt = message.createdAt;
+
+      state.auditLog.push({
+        id: nanoid(),
+        teamId: thread.teamId,
+        actor: senderName,
+        action: 'posted_message',
+        createdAt: message.createdAt,
+        threadId,
+        context: { body: body.slice(0, 120) },
+      });
+    },
+    addReaction: (
+      state,
+      action: PayloadAction<{ threadId: string; messageId: string; memberId: string; emoji: string }>,
+    ) => {
+      const { threadId, messageId, memberId, emoji } = action.payload;
+      const thread = findThread(state, threadId);
+      if (!thread) {
+        return;
+      }
+
+      const message = thread.messages.find((candidate) => candidate.id === messageId);
+      if (!message) {
+        return;
+      }
+
+      const existingReaction = message.reactions.find(
+        (reaction) => reaction.memberId === memberId && reaction.emoji === emoji,
+      );
+
+      if (existingReaction) {
+        return;
+      }
+
+      message.reactions.push({
+        id: nanoid(),
+        emoji,
+        memberId,
+        createdAt: new Date().toISOString(),
+      });
+
+      thread.lastActivityAt = new Date().toISOString();
+    },
+    createPoll: (
+      state,
+      action: PayloadAction<{ threadId: string; question: string; options: string[]; closesAt?: string }>,
+    ) => {
+      const { threadId, question, options, closesAt } = action.payload;
+      const thread = findThread(state, threadId);
+      if (!thread) {
+        return;
+      }
+
+      const poll: ChatPoll = {
+        id: nanoid(),
+        question,
+        createdAt: new Date().toISOString(),
+        closesAt,
+        options: options.map((option) => ({ id: nanoid(), label: option, votes: [] })),
+        closed: false,
+      };
+
+      thread.polls.push(poll);
+      thread.lastActivityAt = poll.createdAt;
+    },
+    voteOnPoll: (
+      state,
+      action: PayloadAction<{ threadId: string; pollId: string; optionId: string; memberId: string }>,
+    ) => {
+      const { threadId, pollId, optionId, memberId } = action.payload;
+      const thread = findThread(state, threadId);
+      if (!thread) {
+        return;
+      }
+
+      const poll = thread.polls.find((candidate) => candidate.id === pollId);
+      if (!poll || poll.closed) {
+        return;
+      }
+
+      poll.options = poll.options.map((option) => {
+        const filteredVotes = option.votes.filter((vote) => vote !== memberId);
+        if (option.id === optionId) {
+          return { ...option, votes: [...filteredVotes, memberId] };
+        }
+
+        return { ...option, votes: filteredVotes };
+      });
+
+      thread.lastActivityAt = new Date().toISOString();
+    },
+    closePoll: (state, action: PayloadAction<{ threadId: string; pollId: string }>) => {
+      const { threadId, pollId } = action.payload;
+      const thread = findThread(state, threadId);
+      if (!thread) {
+        return;
+      }
+
+      const poll = thread.polls.find((candidate) => candidate.id === pollId);
+      if (!poll) {
+        return;
+      }
+
+      poll.closed = true;
+      thread.lastActivityAt = new Date().toISOString();
+    },
+    pinMessage: (state, action: PayloadAction<{ threadId: string; messageId: string }>) => {
+      const { threadId, messageId } = action.payload;
+      const thread = findThread(state, threadId);
+      if (!thread) {
+        return;
+      }
+
+      if (!thread.pinnedMessageIds.includes(messageId)) {
+        thread.pinnedMessageIds.push(messageId);
+      }
+      thread.lastActivityAt = new Date().toISOString();
+    },
+    removeMessage: (state, action: PayloadAction<{ threadId: string; messageId: string; actor: string }>) => {
+      const { threadId, messageId, actor } = action.payload;
+      const thread = findThread(state, threadId);
+      if (!thread) {
+        return;
+      }
+
+      thread.messages = thread.messages.filter((message) => message.id !== messageId);
+      thread.pinnedMessageIds = thread.pinnedMessageIds.filter((id) => id !== messageId);
+      thread.lastActivityAt = new Date().toISOString();
+
+      state.auditLog.push({
+        id: nanoid(),
+        teamId: thread.teamId,
+        actor,
+        action: 'deleted_message',
+        createdAt: new Date().toISOString(),
+        threadId,
+        context: { messageId },
+      });
+    },
+    muteThread: (state, action: PayloadAction<{ threadId: string; muted: boolean }>) => {
+      const { threadId, muted } = action.payload;
+      const thread = findThread(state, threadId);
+      if (!thread) {
+        return;
+      }
+
+      thread.muted = muted;
+      thread.lastActivityAt = new Date().toISOString();
+    },
+    markThreadResolved: (state, action: PayloadAction<{ threadId: string; resolved: boolean }>) => {
+      const { threadId, resolved } = action.payload;
+      const thread = findThread(state, threadId);
+      if (!thread) {
+        return;
+      }
+
+      thread.resolved = resolved;
+      thread.lastActivityAt = new Date().toISOString();
+    },
+    cacheRecentMessages: (state, action: PayloadAction<{ threadId: string; limit?: number }>) => {
+      const { threadId, limit = 50 } = action.payload;
+      const thread = findThread(state, threadId);
+      if (!thread) {
+        return;
+      }
+
+      const cachedMessages: CachedThreadMessages = {
+        threadId,
+        cachedAt: new Date().toISOString(),
+        messages: thread.messages.slice(-limit),
+      };
+
+      const existingIndex = state.cached.findIndex((entry) => entry.threadId === threadId);
+      if (existingIndex >= 0) {
+        state.cached[existingIndex] = cachedMessages;
+      } else {
+        state.cached.push(cachedMessages);
+      }
+    },
+    compressThreadHistory: (state, action: PayloadAction<{ threadId: string; keepLatest?: number }>) => {
+      const { threadId, keepLatest = 100 } = action.payload;
+      const thread = findThread(state, threadId);
+      if (!thread) {
+        return;
+      }
+
+      if (thread.messages.length > keepLatest) {
+        thread.messages = thread.messages.slice(-keepLatest);
+      }
+    },
+    flushOfflineQueue: (state) => {
+      if (state.offlineQueue.length === 0) {
+        return;
+      }
+
+      state.offlineQueue = [];
+      state.lastSyncedAt = new Date().toISOString();
+    },
+    appendAuditLog: (
+      state,
+      action: PayloadAction<{ teamId: string; actor: string; action: string; context?: Record<string, string> }>,
+    ) => {
+      state.auditLog.push({
+        id: nanoid(),
+        teamId: action.payload.teamId,
+        actor: action.payload.actor,
+        action: action.payload.action,
+        createdAt: new Date().toISOString(),
+        context: action.payload.context,
+      });
+    },
+  },
+});
+
+export const {
+  setRealtimeBackend,
+  setRealtimeConnection,
+  createContextualThread,
+  linkThreadMetadata,
+  postMessage,
+  addReaction,
+  createPoll,
+  voteOnPoll,
+  closePoll,
+  pinMessage,
+  removeMessage,
+  muteThread,
+  markThreadResolved,
+  cacheRecentMessages,
+  compressThreadHistory,
+  flushOfflineQueue,
+  appendAuditLog,
+} = teamChatSlice.actions;
+
+export const selectThreadsByTeam = (state: { teamChat: TeamChatState }, teamId: string) =>
+  state.teamChat.threads.filter((thread) => thread.teamId === teamId);
+
+export const selectAuditLogForTeam = (state: { teamChat: TeamChatState }, teamId: string) =>
+  state.teamChat.auditLog.filter((entry) => entry.teamId === teamId);
+
+export default teamChatSlice.reducer;


### PR DESCRIPTION
## Summary
- introduce a dedicated kit design slice with AI prompts, concept generation, voting, production handoff, and vendor/order state
- add a KitDesignBoard workspace and TeamChatPanel to Manage Team for kit workflows, Canva co-creation, voting, and post-launch upsells
- create a realtime-ready team chat slice covering contextual threads, polls, moderation tooling, caching, and integrate both slices with the store

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e5d2359c3c832e87c49dab8b5a5147