### PR TITLE
Prioritize Google Play and web launch in publishing docs

### DIFF
--- a/docs/phase-1-account-legal-playbook.md
+++ b/docs/phase-1-account-legal-playbook.md
@@ -17,7 +17,7 @@ This playbook expands the high-level Phase 1 items from the publishing action pl
    - [ ] Store sanitized evidence in `docs/publishing/evidence/accounts/`.
 2. **Document ownership & billing**
    - [ ] Record the primary owners, backup admins, and billing contacts for each store.
-   - [ ] Note renewal dates (Apple yearly fee, Play Console one-time) and add reminders to the team calendar.
+   - [ ] Note renewal dates (Apple yearly US\$99 USD fee, Google Play one-time US\$25 USD fee) and add reminders to the team calendar.
    - [ ] Save a `ACCOUNTS.md` summary in `docs/publishing`.
 3. **Set up access management**
    - [ ] Audit user roles, removing unused accounts and applying least-privilege roles.

--- a/docs/publishing-action-plan.md
+++ b/docs/publishing-action-plan.md
@@ -2,6 +2,8 @@
 
 This plan converts the outstanding items from [`publishing-status.md`](./publishing-status.md) into an actionable workflow. Tasks are grouped by phase and sequenced so that prerequisites unblock downstream submission steps for Google Play and the Apple App Store.
 
+> **Launch focus.** The immediate objective is to ship the Android build to Google Play and cut a production web deployment. App Store submission will follow after the Google Play/web release stabilizes, so the plan below highlights the work that can progress now and flags the iOS tasks that should remain in the backlog until that milestone is complete.
+
 ## Phase 1 – Account access and legal readiness
 1. **Confirm developer program enrollment** *(see [Phase 1 playbook](./phase-1-account-legal-playbook.md))*
    - Verify active ownership of the Google Play Console and Apple Developer Program accounts.
@@ -47,21 +49,31 @@ This plan converts the outstanding items from [`publishing-status.md`](./publish
     - Complete an internal audit against Google Play policies and the App Store Review Guidelines.
     - Update the app or documentation to address any potential violations.
 
-## Phase 5 – Store submission execution
-13. **Prepare Google Play release**
+## Phase 5 – Launch execution (Google Play + Web)
+13. **Prepare production web deployment**
+    - Provision Firebase Hosting credentials (service account JSON or CI token) and store them in the appropriate secret manager.
+    - Verify the Node.js 20 deploy pipeline and rerun the automated deploy workflow until it succeeds end-to-end.
+    - Capture a smoke-test checklist for the web build (routing, auth, live data) and note the version that is pushed to production.
+14. **Prepare Google Play release**
     - Create the application record, populate the main store listing, and upload imagery.
     - Complete the App Content questionnaire, pricing & distribution, and upload the release AAB with notes.
     - Resolve pre-launch warnings, then submit the production release for review and monitor status.
-14. **Prepare App Store release**
-    - Create the App Store Connect app record with metadata, categories, age rating, and content rights.
+    - Record a "Play launch complete" date so the team knows when to kick off the App Store backlog.
+
+## Phase 6 – App Store submission (deferred until after Play/web launch)
+15. **Stage App Store assets and disclosures**
+    - Keep gathering metadata, screenshots, privacy responses, and signed builds so they are ready when the App Store window opens.
+    - Track open dependencies (e.g., consent UX parity, any iOS-specific features) in the issue tracker and assign owners ahead of time.
+16. **Execute App Store release**
+    - When the team is ready, create the App Store Connect app record with metadata, categories, age rating, and content rights.
     - Upload required screenshots, previews, and the signed IPA build.
     - Configure App Privacy responses, attach release notes, submit for review, and handle any feedback.
 
-## Phase 6 – Post-launch operations
-15. **Establish monitoring and feedback loops**
+## Phase 7 – Post-launch operations
+17. **Establish monitoring and feedback loops**
     - Configure analytics dashboards, crash reporting alerts, and review response processes.
     - Schedule periodic store listing refreshes and policy compliance reviews.
-16. **Plan release cadence**
+18. **Plan release cadence**
     - Define criteria for hotfixes versus feature releases.
     - Document a roadmap for post-launch iterations and assign owners.
 

--- a/docs/publishing-guide.md
+++ b/docs/publishing-guide.md
@@ -2,10 +2,12 @@
 
 This checklist summarizes the key steps required to launch the application on both Google Play and the Apple App Store.
 
+> **Release strategy:** Prioritize shipping the Android build to Google Play and deploying the production web app first. Keep gathering the Apple App Store assets in parallel, but plan to submit to Apple only after the Google Play/web release stabilizes.
+
 ## Prerequisites
 - **Developer accounts**
-  - Enroll in the [Google Play Console](https://play.google.com/console) with a one-time registration fee.
-  - Enroll in the [Apple Developer Program](https://developer.apple.com/programs/) and maintain the annual membership.
+  - Enroll in the [Google Play Console](https://play.google.com/console) with a one-time US\$25 USD registration fee (or the local-currency equivalent collected by Google).
+  - Enroll in the [Apple Developer Program](https://developer.apple.com/programs/) and maintain the annual US\$99 USD membership (waived for approved nonprofits, schools, or governments).
 - **App assets ready**
   - Final app name, description, keywords, and privacy policy URL.
   - High-resolution icon, feature graphics, and screenshots that meet the store guidelines for all targeted devices.
@@ -37,7 +39,13 @@ This checklist summarizes the key steps required to launch the application on bo
 5. Complete **Pre-launch checks** and resolve any warnings (e.g., policy issues, performance, security) reported by Google.
 6. Submit the release for **review** and monitor the review status until it is approved and published.
 
-## Apple App Store submission steps
+## Production web deployment steps
+1. Provision Firebase Hosting access by supplying either a service account key or deploy token to the CI/CD secret store.
+2. Update the deployment workflow to run on **Node.js 20**, confirm dependencies install without `EBADENGINE` warnings, and re-run the pipeline until the `firebase deploy` step succeeds.
+3. Smoke test the live site (navigation, authentication, live data, error pages) after each deployment and document the release version.
+4. Capture evidence of the deployed URL, timestamp, and any follow-up tickets opened from smoke-test findings.
+
+## Apple App Store submission steps *(queued after Google Play/web launch)*
 1. Log in to App Store Connect, create a new app record, and enter metadata (name, subtitle, description, keywords, support URL, marketing URL).
 2. Upload required **App Store assets**: screenshots for each device size, app previews, and promotional text.
 3. Provide the **App Privacy** responses and attach the privacy policy URL.

--- a/docs/publishing-status.md
+++ b/docs/publishing-status.md
@@ -36,16 +36,23 @@ This document tracks the current completion status of each task in the mobile pu
 | Resolve pre-launch check warnings | Outstanding | No pre-launch reports captured. |
 | Submit for review and monitor approval | Outstanding | Submission has not been initiated. |
 
-## Apple App Store submission steps
+## Web deployment steps
 | Step | Status | Notes |
 | --- | --- | --- |
-| Create App Store Connect record with metadata | Outstanding | No App Store Connect metadata stored. |
-| Upload device screenshots and previews | Outstanding | Media assets are missing. |
-| Provide App Privacy responses and policy URL | Outstanding | Privacy disclosures not documented. |
-| Configure categories, age rating, content rights | Outstanding | Settings not recorded. |
-| Upload signed IPA build via Xcode/Transporter | Outstanding | No build artifacts tracked. |
-| Attach build to App Store version and add release notes | Outstanding | Not yet prepared. |
-| Submit for App Review and respond to feedback | Outstanding | Submission has not occurred. |
+| Provision Firebase Hosting credentials | Outstanding | Deploy workflow still fails because credentials have not been provided. |
+| Verify Node.js 20 pipeline and rerun deploy | Outstanding | Latest deploy run hit missing credential errors before validating Node 20. |
+| Document smoke-test checklist & production URL | Outstanding | No production deployment evidence is stored. |
+
+## Apple App Store submission steps *(deferred until after Google Play/web launch)*
+| Step | Status | Notes |
+| --- | --- | --- |
+| Create App Store Connect record with metadata | Outstanding | Work is intentionally queued until the Google Play/web launch stabilizes. |
+| Upload device screenshots and previews | Outstanding | Asset production continues but submission is deferred. |
+| Provide App Privacy responses and policy URL | Outstanding | Privacy disclosures being drafted for later submission. |
+| Configure categories, age rating, content rights | Outstanding | Settings will be defined when Apple submission window opens. |
+| Upload signed IPA build via Xcode/Transporter | Outstanding | Build pipeline not yet targeted because the App Store launch is deferred. |
+| Attach build to App Store version and add release notes | Outstanding | Release notes and build attachment scheduled post-Google Play launch. |
+| Submit for App Review and respond to feedback | Outstanding | Submission will occur after the Android/web release is live. |
 
 ## Post-launch maintenance
 | Item | Status | Notes |


### PR DESCRIPTION
## Summary
- highlight the near-term focus on shipping Google Play and a production web deployment before turning to the App Store
- add dedicated web deployment steps to the publishing checklist and track them in the status log alongside deferred iOS work
- expand the action plan to cover Firebase hosting readiness and mark App Store submission as a follow-up phase after the Play/web launch

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e5c2cdf81c832e8fd1601cd501f37c