### PR TITLE
Align kit chat metadata with kit projects

### DIFF
--- a/docs/additional-feature-ideas.md
+++ b/docs/additional-feature-ideas.md
@@ -26,3 +26,18 @@ This document captures high-level feature concepts that can guide future develop
 - Deliver training plans, nutrition advice, or recovery tips tailored to each user’s stored demographics and preferences.
 - Offer premium-gated content tiers that provide deeper guidance, video walkthroughs, or personalized coaching plans.
 - Use push notifications or in-app reminders to keep players on track with their selected regimens.
+
+## Collaborative Kit Lab Extensions
+- Layer in approval analytics that visualise squad sentiment trends across each kit revision, highlighting where feedback clusters.
+- Provide automated production checklists that track vendor milestones, sample sign-offs, and delivery ETAs alongside the design thread.
+- Introduce supporter-facing drops for limited edition merch once a kit is approved, tying purchases to the existing wallet system.
+
+## Team Communications Enhancements
+- Offer presence indicators and read receipts within the live chat so captains can confirm who has seen critical updates.
+- Allow message-level tasks (e.g. “Follow up on travel coach booking”) that sync with the team calendar and resolve automatically when marked complete.
+- Bundle contextual chat summaries after intense activity, using AI to recap action items and decisions for members who were offline.
+
+## Immersive Matchday Companion
+- Generate AI-driven tactical insights that surface during live match threads, such as suggested substitutions based on player fatigue trends.
+- Stream lightweight audio rooms where fans and players can co-host commentary during marquee fixtures.
+- Sync live match stats with wearable data for premium teams, unlocking deeper performance breakdowns post-game.

--- a/football-app/scripts/run-tests.js
+++ b/football-app/scripts/run-tests.js
@@ -51,4 +51,26 @@ function readSource(relativePath) {
   );
 })();
 
+(function verifyKitAndChatIntegration() {
+  const kitBoard = readSource('src/components/KitDesignBoard.tsx');
+  assert(
+    kitBoard.includes('linkThreadMetadata'),
+    'Kit design board should sync kit projects with the associated chat thread metadata',
+  );
+  assert(
+    kitBoard.includes('metadata: { relatedKitProjectId: project.id }'),
+    'Kit design board should link the active project to the contextual chat thread',
+  );
+
+  const teamChat = readSource('src/components/TeamChatPanel.tsx');
+  assert(
+    teamChat.includes('metadata: { relatedKitProjectId: kitProjects[0].id }'),
+    'Team chat panel should seed kit threads with the initial project metadata',
+  );
+  assert(
+    teamChat.includes('metadata: { relatedKitProjectId: activeKitProjectId }'),
+    'Team chat panel should keep the kit thread metadata in sync with the latest project',
+  );
+})();
+
 console.log('All assertions passed.');

--- a/football-app/src/components/KitDesignBoard.tsx
+++ b/football-app/src/components/KitDesignBoard.tsx
@@ -31,7 +31,11 @@ import {
   updateConceptTaskStatus,
   updateKitBrief,
 } from '../store/slices/kitDesignSlice';
-import { createContextualThread, selectThreadsByTeam } from '../store/slices/teamChatSlice';
+import {
+  createContextualThread,
+  linkThreadMetadata,
+  selectThreadsByTeam,
+} from '../store/slices/teamChatSlice';
 
 interface KitDesignBoardProps {
   teamId: string;
@@ -70,6 +74,23 @@ const KitDesignBoard: React.FC<KitDesignBoardProps> = ({ teamId, teamName }) => 
       dispatch(attachChatThread({ projectId: project.id, threadId: kitThread.id }));
     }
   }, [project, kitThread, dispatch]);
+
+  useEffect(() => {
+    if (!project || !kitThread) {
+      return;
+    }
+
+    if (kitThread.metadata?.relatedKitProjectId === project.id) {
+      return;
+    }
+
+    dispatch(
+      linkThreadMetadata({
+        threadId: kitThread.id,
+        metadata: { relatedKitProjectId: project.id },
+      }),
+    );
+  }, [project?.id, kitThread?.id, kitThread?.metadata?.relatedKitProjectId, dispatch]);
 
   useEffect(() => {
     if (!project) {

--- a/football-app/src/components/TeamChatPanel.tsx
+++ b/football-app/src/components/TeamChatPanel.tsx
@@ -8,6 +8,7 @@ import {
   createContextualThread,
   createPoll,
   markThreadResolved,
+  linkThreadMetadata,
   muteThread,
   pinMessage,
   postMessage,
@@ -27,6 +28,7 @@ const TeamChatPanel: React.FC<TeamChatPanelProps> = ({ teamId }) => {
   const threads = useAppSelector((state) => selectThreadsByTeam(state, teamId));
   const chatState = useAppSelector((state) => state.teamChat);
   const kitProjects = useAppSelector((state) => selectKitProjectsByTeam(state, teamId));
+  const activeKitProjectId = kitProjects[0]?.id;
   const kitThread = useMemo(() => threads.find((thread) => thread.type === 'kit'), [threads]);
   const matchdayThread = useMemo(
     () => threads.find((thread) => thread.type === 'matchday'),
@@ -78,6 +80,23 @@ const TeamChatPanel: React.FC<TeamChatPanelProps> = ({ teamId }) => {
       );
     }
   }, [matchdayThread, announcementThread, dispatch, teamId]);
+
+  useEffect(() => {
+    if (!kitThread || !activeKitProjectId) {
+      return;
+    }
+
+    if (kitThread.metadata?.relatedKitProjectId === activeKitProjectId) {
+      return;
+    }
+
+    dispatch(
+      linkThreadMetadata({
+        threadId: kitThread.id,
+        metadata: { relatedKitProjectId: activeKitProjectId },
+      }),
+    );
+  }, [kitThread?.id, kitThread?.metadata?.relatedKitProjectId, activeKitProjectId, dispatch]);
 
   const handleSendMessage = (threadId: string) => {
     const body = messageDrafts[threadId]?.trim();


### PR DESCRIPTION
## Summary
- sync kit design projects with their contextual chat threads so approvals stay linked
- ensure the team chat panel seeds and maintains kit thread metadata for the active project
- extend automated checks and documentation with new collaboration feature ideas

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e5cd908774832e80dd237d15e10c43