### PR TITLE
Document DUNS number and outstanding store access follow-ups

### DIFF
--- a/docs/publishing-status.md
+++ b/docs/publishing-status.md
@@ -5,8 +5,8 @@ This document tracks the current completion status of each task in the mobile pu
 ## Prerequisites
 | Item | Status | Notes |
 | --- | --- | --- |
-| Google Play Console developer account enrollment | Outstanding | Requires confirmation of account ownership; no repository evidence available. |
-| Apple Developer Program enrollment | Outstanding | Requires confirmation of account ownership; no repository evidence available. |
+| Google Play Console developer account enrollment | Outstanding | D-U-N-S record captured in `docs/publishing/ACCOUNTS.md`, but console access evidence and contact assignments are still missing. |
+| Apple Developer Program enrollment | Outstanding | D-U-N-S record captured in `docs/publishing/ACCOUNTS.md`; need sanitized screenshot showing active membership and contact details. |
 | Store-ready app name, description, keywords, privacy policy URL | Outstanding | Store metadata has not been captured in the repository. |
 | High-resolution icons, feature graphics, screenshots | Outstanding | `assets/icons` only contains a placeholder file—store imagery still needs to be produced. |
 | Promotional video or trailer | Outstanding | No media assets or references are tracked in the repository. |

--- a/docs/publishing/ACCOUNTS.md
+++ b/docs/publishing/ACCOUNTS.md
@@ -1,0 +1,21 @@
+# Store Account Summary
+
+This document tracks high-level ownership details for the app store accounts used to publish the Football App.
+
+## Google Play Console
+- **Publisher account status:** Pending verification
+- **Primary contact:** _TBD_
+- **Billing owner:** _TBD_
+- **Notes:** Provide a sanitized screenshot of the Google Play Console dashboard in `docs/publishing/evidence/accounts/` to confirm active access. Document the support email, physical mailing address, and phone number that will appear on the store listing.
+
+## Apple Developer Program (for future App Store submission)
+- **D-U-N-S® number:** `235588932`
+- **Program status:** Pending confirmation of enrollment
+- **Primary contact:** _TBD_
+- **Billing owner:** _TBD_
+- **Notes:** Apple uses the D-U-N-S number to validate the legal entity. Capture proof of the account’s "Active" status and mask any sensitive billing details before committing evidence to the repository.
+
+## Next steps
+1. Confirm who administers each account and fill in the contact fields above.
+2. Upload sanitized console screenshots that demonstrate active access to both stores.
+3. Update `docs/publishing-status.md` once verification artifacts are in place so downstream publishing tasks can proceed.


### PR DESCRIPTION
## Summary
- add a store account summary document capturing the provided D-U-N-S number and pending ownership details
- note in the publishing status checklist that the D-U-N-S record now exists but console access evidence is still required

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68e84b26247c832e8f493435ba5899e4