### PR TITLE
Document Google Play enrollment form guidance

### DIFF
--- a/docs/publishing-status.md
+++ b/docs/publishing-status.md
@@ -5,8 +5,8 @@ This document tracks the current completion status of each task in the mobile pu
 ## Prerequisites
 | Item | Status | Notes |
 | --- | --- | --- |
-| Google Play Console developer account enrollment | Outstanding | Requires confirmation of account ownership; no repository evidence available. |
-| Apple Developer Program enrollment | Outstanding | Requires confirmation of account ownership; no repository evidence available. |
+| Google Play Console developer account enrollment | Outstanding | Follow the step-by-step form guidance in `docs/publishing/ACCOUNTS.md`, then upload the masked enrollment screenshot and assign primary/billing contacts. |
+| Apple Developer Program enrollment | Outstanding | D-U-N-S record captured in `docs/publishing/ACCOUNTS.md`; need sanitized screenshot showing active membership and contact details. |
 | Store-ready app name, description, keywords, privacy policy URL | Outstanding | Store metadata has not been captured in the repository. |
 | High-resolution icons, feature graphics, screenshots | Outstanding | `assets/icons` only contains a placeholder file—store imagery still needs to be produced. |
 | Promotional video or trailer | Outstanding | No media assets or references are tracked in the repository. |

--- a/docs/publishing-status.md
+++ b/docs/publishing-status.md
@@ -5,7 +5,7 @@ This document tracks the current completion status of each task in the mobile pu
 ## Prerequisites
 | Item | Status | Notes |
 | --- | --- | --- |
-| Google Play Console developer account enrollment | Outstanding | Follow the step-by-step form guidance in `docs/publishing/ACCOUNTS.md`, then upload the masked enrollment screenshot and assign primary/billing contacts. |
+| Google Play Console developer account enrollment | Outstanding | Follow the step-by-step form guidance in `docs/publishing/ACCOUNTS.md` (including the final screen field breakdown), then upload the masked enrollment screenshot and assign primary/billing contacts. |
 | Apple Developer Program enrollment | Outstanding | D-U-N-S record captured in `docs/publishing/ACCOUNTS.md`; need sanitized screenshot showing active membership and contact details. |
 | Store-ready app name, description, keywords, privacy policy URL | Outstanding | Store metadata has not been captured in the repository. |
 | High-resolution icons, feature graphics, screenshots | Outstanding | `assets/icons` only contains a placeholder file—store imagery still needs to be produced. |

--- a/docs/publishing/ACCOUNTS.md
+++ b/docs/publishing/ACCOUNTS.md
@@ -14,6 +14,14 @@ This document tracks high-level ownership details for the app store accounts use
 3. **Gather evidence before submission.** Have ready: the business legal name that matches the D-U-N-S record, support email, public phone number, physical address, and a payment card for the one-time US\$25 fee. Capture a masked screenshot of the completed form before submitting so it can be archived in `docs/publishing/evidence/accounts/`.
 4. **Submit and await identity verification.** After paying the fee and submitting the form, watch for the confirmation email. Google may request additional documents (e.g., utility bill or government registration). Save any correspondence and upload redacted copies to the evidence folder once received.
 
+#### Completing the final Google Play sign-up screen (last shared screenshot)
+- **Developer name:** Enter the public-facing business name that matches the D-U-N-S® record (`235588932`). This is what appears on the Google Play store listing.
+- **Contact email:** Use the official support or helpdesk mailbox that end users should reach out to (e.g., `support@footballapp.example`). Avoid personal inboxes.
+- **Contact phone:** Provide the business phone line monitored for store inquiries. Include the country code and ensure voicemail is configured.
+- **Website URL (if requested):** Supply the production marketing site or landing page for the Football App. If the site is still under construction, link to the best live page with basic product information.
+- **Business address:** Fill in the registered street address associated with the D-U-N-S® listing so Google can verify the legal entity.
+- **Archive proof:** Before clicking **Save**, capture a masked screenshot of the completed page and store it under `docs/publishing/evidence/accounts/` for audit purposes.
+
 ## Apple Developer Program (for future App Store submission)
 - **D-U-N-S® number:** `235588932`
 - **Program status:** Pending confirmation of enrollment

--- a/docs/publishing/ACCOUNTS.md
+++ b/docs/publishing/ACCOUNTS.md
@@ -1,0 +1,27 @@
+# Store Account Summary
+
+This document tracks high-level ownership details for the app store accounts used to publish the Football App.
+
+## Google Play Console
+- **Publisher account status:** Pending verification
+- **Primary contact:** _TBD_
+- **Billing owner:** _TBD_
+- **Notes:** Provide a sanitized screenshot of the Google Play Console dashboard in `docs/publishing/evidence/accounts/` to confirm active access. Document the support email, physical mailing address, and phone number that will appear on the store listing.
+
+### Enrollment walkthrough (matches the Google Play sign-up screenshot)
+1. **Tell Google about our experience.** In the **Your Play Console and Android experience** box, summarize any prior publishing work (or explicitly call out that this will be the first Play Console app) and restate that we are registering the Football App company account. Mention the D-U-N-S® number (`235588932`) so Google can cross-check the legal entity, and note that the app targets association football fans.
+2. **Disclose existing Google Play access.** In the **Other Google Accounts** section, list any Google Accounts that already manage Play Console organizations for the team. If nobody has prior access, choose the "No" option so Google knows this is a fresh registration.
+3. **Gather evidence before submission.** Have ready: the business legal name that matches the D-U-N-S record, support email, public phone number, physical address, and a payment card for the one-time US\$25 fee. Capture a masked screenshot of the completed form before submitting so it can be archived in `docs/publishing/evidence/accounts/`.
+4. **Submit and await identity verification.** After paying the fee and submitting the form, watch for the confirmation email. Google may request additional documents (e.g., utility bill or government registration). Save any correspondence and upload redacted copies to the evidence folder once received.
+
+## Apple Developer Program (for future App Store submission)
+- **D-U-N-S® number:** `235588932`
+- **Program status:** Pending confirmation of enrollment
+- **Primary contact:** _TBD_
+- **Billing owner:** _TBD_
+- **Notes:** Apple uses the D-U-N-S number to validate the legal entity. Capture proof of the account’s "Active" status and mask any sensitive billing details before committing evidence to the repository.
+
+## Next steps
+1. Confirm who administers each account and fill in the contact fields above.
+2. Upload sanitized console screenshots that demonstrate active access to both stores.
+3. Update `docs/publishing-status.md` once verification artifacts are in place so downstream publishing tasks can proceed.


### PR DESCRIPTION
## Summary
- add step-by-step instructions to the store account summary for completing the Google Play signup form seen in the screenshot
- point the publishing checklist to the new walkthrough so enrollment evidence can be captured

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68e84b26247c832e8f493435ba5899e4