### PR TITLE
Configure Android release signing properties

### DIFF
--- a/football-app/gradle.properties
+++ b/football-app/gradle.properties
@@ -1,0 +1,4 @@
+MYAPP_UPLOAD_STORE_FILE=my-release-key.jks
+MYAPP_UPLOAD_KEY_ALIAS=my-key-alias
+MYAPP_UPLOAD_STORE_PASSWORD=my-store-password
+MYAPP_UPLOAD_KEY_PASSWORD=my-key-password


### PR DESCRIPTION
## Summary
- add release keystore configuration values to `gradle.properties`

## Testing
- not run (gradle wrapper missing in repository)


------
https://chatgpt.com/codex/tasks/task_b_68e9a7a7a0a88332a76387d1ae5ed223