### PR TITLE
Define CommunicationDigestEntry type alias

### DIFF
--- a/football-app/src/screens/TeamScreen.tsx
+++ b/football-app/src/screens/TeamScreen.tsx
@@ -20,6 +20,12 @@ import {
 } from '../store/slices/scheduleSlice';
 import type { CommunicationStatus, TeamCommunication } from '../store/slices/communicationsSlice';
 
+type CommunicationDigestEntry = {
+  title: string;
+  status: CommunicationStatus;
+  timestamp: string | null;
+};
+
 type TeamScreenNavigationProp = CompositeNavigationProp<
   BottomTabNavigationProp<AuthenticatedTabParamList, 'ManageTeams'>,
   NativeStackNavigationProp<RootStackParamList>


### PR DESCRIPTION
## Summary
- declare a CommunicationDigestEntry type to describe items in the communication digest
- keep the selector annotated with the new alias so the compiler recognizes the shape

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68e9b5f8c2bc83328fd00d7089b0fc98