### PR TITLE
Pass schedule summary data to TeamCard components

### DIFF
--- a/football-app/src/screens/TeamScreen.tsx
+++ b/football-app/src/screens/TeamScreen.tsx
@@ -118,13 +118,21 @@ const TeamScreen: React.FC = () => {
         data={teams}
         keyExtractor={(item: Team) => item.id}
         contentContainerStyle={styles.listContent}
-        renderItem={({ item }: { item: Team }) => (
-          <TeamCard
-            team={item}
-            onRemove={() => dispatch(removeTeam(item.id))}
-            onManage={() => navigation.navigate('ManageTeam', { teamId: item.id })}
-          />
-        )}
+        renderItem={({ item }: { item: Team }) => {
+          const teamSummary = scheduleSummary[item.id];
+          const teamCommunication = communicationDigest[item.id];
+
+          return (
+            <TeamCard
+              team={item}
+              onRemove={() => dispatch(removeTeam(item.id))}
+              onManage={() => navigation.navigate('ManageTeam', { teamId: item.id })}
+              record={teamSummary?.record}
+              nextFixtureLabel={teamSummary?.nextFixtureLabel}
+              latestCommunication={teamCommunication}
+            />
+          );
+        }}
         ListEmptyComponent={<Text style={styles.emptyText}>Create your first team to get started.</Text>}
       />
 


### PR DESCRIPTION
## Summary
- supply schedule summaries and communication digests to each TeamCard on the Team screen
- guard against missing data via optional chaining so empty states still render

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_b_68e9b5fdaf148332bf969cf8ca48449a