### PR TITLE
Enhance team cards with scheduling helpers and tests

### DIFF
--- a/football-app/src/components/teamCardFormatting.ts
+++ b/football-app/src/components/teamCardFormatting.ts
@@ -1,0 +1,56 @@
+import type { Fixture } from '../store/slices/scheduleSlice';
+import { formatKickoffTime, getFixtureStartDate } from '../store/slices/scheduleSlice';
+
+export interface CommunicationDigestEntry {
+  id: string;
+  sender: string;
+  message: string;
+  date: string;
+}
+
+export interface FormattedFixtureSummary {
+  id: string;
+  opponent: string;
+  kickoffLabel: string;
+  location: string;
+  status: Fixture['status'];
+}
+
+export interface FormattedCommunicationEntry extends CommunicationDigestEntry {
+  formattedDate: string;
+}
+
+export const formatFixturesForDisplay = (nextFixtures: Fixture[]): FormattedFixtureSummary[] =>
+  nextFixtures.map((fixture) => {
+    const startDate = getFixtureStartDate(fixture);
+    const kickoffLabel = startDate ? formatKickoffTime(startDate.toISOString()) : 'Kickoff TBC';
+
+    return {
+      id: fixture.id,
+      opponent: fixture.opponent,
+      kickoffLabel,
+      location: fixture.location,
+      status: fixture.status,
+    };
+  });
+
+export const formatCommunicationDigest = (
+  communications: CommunicationDigestEntry[],
+): FormattedCommunicationEntry[] =>
+  communications.map((entry) => {
+    const date = new Date(entry.date);
+    const formattedDate = Number.isNaN(date.getTime())
+      ? entry.date
+      : date.toLocaleString(undefined, {
+          weekday: 'short',
+          month: 'short',
+          day: 'numeric',
+          hour: '2-digit',
+          minute: '2-digit',
+        });
+
+    return {
+      ...entry,
+      formattedDate,
+    };
+  });

--- a/football-app/src/screens/teamScreenData.ts
+++ b/football-app/src/screens/teamScreenData.ts
@@ -1,0 +1,114 @@
+import type { Team } from '../store/slices/teamsSlice';
+import type { TeamCommunication } from '../store/slices/communicationsSlice';
+import type { Fixture } from '../store/slices/scheduleSlice';
+import {
+  formatKickoffTime,
+  getFixtureStartDate,
+  selectFixturesByTeam,
+  selectNextFixtureForTeam,
+  selectTeamRecord,
+} from '../store/slices/scheduleSlice';
+import type { RootState } from '../store';
+import type { CommunicationDigestEntry } from '../components/teamCardFormatting';
+
+export interface TeamScheduleSummaryEntry {
+  record: { wins: number; draws: number; losses: number };
+  nextFixtureLabel?: string;
+  nextFixtures: Fixture[];
+}
+
+export type TeamScheduleSummary = Record<string, TeamScheduleSummaryEntry>;
+
+export type TeamCommunicationDigest = Record<string, CommunicationDigestEntry[]>;
+
+export interface TeamCardData {
+  team: Team;
+  record?: TeamScheduleSummaryEntry['record'];
+  nextFixtureLabel?: string;
+  nextFixtures: Fixture[];
+  communications: CommunicationDigestEntry[];
+}
+
+const buildNextFixtureLabel = (fixture: Fixture | undefined): string | undefined => {
+  if (!fixture) {
+    return undefined;
+  }
+
+  const kickoffOption = fixture.acceptedKickoffOptionId
+    ? fixture.kickoffOptions.find((option) => option.id === fixture.acceptedKickoffOptionId)
+    : fixture.kickoffOptions
+        .slice()
+        .sort((a, b) => new Date(a.isoTime).getTime() - new Date(b.isoTime).getTime())[0];
+
+  if (!kickoffOption) {
+    return fixture.opponent;
+  }
+
+  return `${fixture.opponent} • ${formatKickoffTime(kickoffOption.isoTime)}`;
+};
+
+export const buildScheduleSummary = (
+  state: RootState,
+  teams: Team[],
+): TeamScheduleSummary => {
+  const summary: TeamScheduleSummary = {};
+
+  teams.forEach((team) => {
+    const record = selectTeamRecord(state, team.id);
+    const nextFixture = selectNextFixtureForTeam(state, team.id);
+    const upcomingFixtures = selectFixturesByTeam(state, team.id)
+      .filter((fixture) => fixture.status !== 'completed')
+      .sort((a, b) => {
+        const aDate = getFixtureStartDate(a)?.getTime() ?? Number.POSITIVE_INFINITY;
+        const bDate = getFixtureStartDate(b)?.getTime() ?? Number.POSITIVE_INFINITY;
+        return aDate - bDate;
+      });
+
+    summary[team.id] = {
+      record,
+      nextFixtureLabel: buildNextFixtureLabel(nextFixture),
+      nextFixtures: upcomingFixtures.slice(0, 3),
+    };
+  });
+
+  return summary;
+};
+
+export const buildCommunicationDigest = (
+  state: RootState,
+  teams: Team[],
+): TeamCommunicationDigest => {
+  const digest: TeamCommunicationDigest = {};
+  const communications: TeamCommunication[] = state.communications.communications;
+
+  teams.forEach((team) => {
+    const teamCommunications = communications
+      .filter((item) => item.teamId === team.id)
+      .slice()
+      .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
+      .slice(0, 3)
+      .map<CommunicationDigestEntry>((item) => ({
+        id: item.id,
+        sender: 'Team Staff',
+        message: item.title,
+        date: item.status === 'scheduled' && item.scheduledFor ? item.scheduledFor : item.createdAt,
+      }));
+
+    digest[team.id] = teamCommunications;
+  });
+
+  return digest;
+};
+
+export const buildTeamCardsData = (
+  teams: Team[],
+  scheduleSummary: TeamScheduleSummary,
+  communicationDigest: TeamCommunicationDigest,
+): TeamCardData[] =>
+  teams.map((team) => ({
+    team,
+    record: scheduleSummary[team.id]?.record,
+    nextFixtureLabel: scheduleSummary[team.id]?.nextFixtureLabel,
+    nextFixtures: scheduleSummary[team.id]?.nextFixtures ?? [],
+    communications: communicationDigest[team.id] ?? [],
+  }));

--- a/football-app/src/tests/teamCardFormatting.test.tsx
+++ b/football-app/src/tests/teamCardFormatting.test.tsx
@@ -1,0 +1,179 @@
+import { strict as assert } from 'assert';
+import React from 'react';
+import TestRenderer from 'react-test-renderer';
+import type { Team } from '../store/slices/teamsSlice';
+import type { Fixture } from '../store/slices/scheduleSlice';
+import type { CommunicationDigestEntry } from '../components/teamCardFormatting';
+import TeamCard from '../components/TeamCard';
+import { formatCommunicationDigest, formatFixturesForDisplay } from '../components/teamCardFormatting';
+
+const defaultSettings: Team['settings'] = {
+  allowJoinRequests: true,
+  notifyMembersOfChanges: true,
+  shareAvailabilityCalendar: false,
+  autoCollectMatchStats: false,
+};
+
+const collectTextContent = (node: TestRenderer.ReactTestRendererNode): string[] => {
+  if (!node) {
+    return [];
+  }
+
+  if (typeof node === 'string') {
+    return [node];
+  }
+
+  if (Array.isArray(node)) {
+    return node.flatMap(collectTextContent);
+  }
+
+  return collectTextContent(node.children as TestRenderer.ReactTestRendererNode);
+};
+
+export const runTeamCardFormattingTests = () => {
+  (function formatFixturesUsesKickoffOrFallback() {
+    const fixtures: Fixture[] = [
+      {
+        id: 'fixture-1',
+        teamId: 'team-1',
+        opponent: 'Rivals FC',
+        location: 'Home Ground',
+        status: 'scheduled',
+        kickoffOptions: [
+          { id: 'kickoff-1', isoTime: '2024-05-01T18:00:00.000Z', votes: 5 },
+        ],
+        acceptedKickoffOptionId: 'kickoff-1',
+        calendarSynced: false,
+        result: null,
+        notes: undefined,
+        lastUpdated: '2024-04-01T12:00:00.000Z',
+      },
+      {
+        id: 'fixture-2',
+        teamId: 'team-1',
+        opponent: 'Unknown XI',
+        location: 'Training Pitch',
+        status: 'proposed',
+        kickoffOptions: [],
+        acceptedKickoffOptionId: null,
+        calendarSynced: false,
+        result: null,
+        notes: undefined,
+        lastUpdated: '2024-04-01T12:00:00.000Z',
+      },
+    ];
+
+    const formatted = formatFixturesForDisplay(fixtures);
+    assert.equal(formatted.length, 2);
+    assert.equal(formatted[0].opponent, 'Rivals FC');
+    assert.ok(
+      formatted[0].kickoffLabel.includes('Rivals FC') === false,
+      'Kickoff label should only contain the formatted time',
+    );
+    assert.equal(formatted[1].kickoffLabel, 'Kickoff TBC');
+  })();
+
+  (function formatCommunicationsHandlesInvalidDates() {
+    const communications: CommunicationDigestEntry[] = [
+      {
+        id: 'comm-1',
+        sender: 'Coach',
+        message: 'Training moved',
+        date: '2024-04-02T18:30:00.000Z',
+      },
+      {
+        id: 'comm-2',
+        sender: 'Coach',
+        message: 'Bring boots',
+        date: 'Invalid date',
+      },
+    ];
+
+    const formatted = formatCommunicationDigest(communications);
+    assert.equal(formatted.length, 2);
+    assert.equal(formatted[1].formattedDate, 'Invalid date');
+    assert.notEqual(formatted[0].formattedDate, communications[0].date);
+  })();
+
+  (function formattingFunctionsArePureForEmptyInput() {
+    assert.deepEqual(formatFixturesForDisplay([]), []);
+    assert.deepEqual(formatCommunicationDigest([]), []);
+  })();
+
+  (function teamCardRendersEmptyStates() {
+    const team: Team = { id: 'team-1', name: 'Alpha FC', members: [], settings: defaultSettings };
+    let renderer: TestRenderer.ReactTestRenderer;
+
+    TestRenderer.act(() => {
+      renderer = TestRenderer.create(
+        <TeamCard
+          team={team}
+          onRemove={() => {}}
+          onManage={() => {}}
+          record={{ wins: 0, draws: 0, losses: 0 }}
+          nextFixtureLabel={undefined}
+          nextFixtures={[]}
+          communications={[]}
+        />,
+      );
+    });
+
+    const textContent = collectTextContent(renderer!.toJSON());
+    assert.ok(textContent.includes('No upcoming fixtures scheduled.'));
+    assert.ok(textContent.includes('No recent messages.'));
+  })();
+
+  (function teamCardRendersUpcomingDetails() {
+    const team: Team = {
+      id: 'team-2',
+      name: 'Bravo FC',
+      members: [],
+      settings: defaultSettings,
+    };
+    const fixtures: Fixture[] = [
+      {
+        id: 'fixture-3',
+        teamId: 'team-2',
+        opponent: 'Derby County',
+        location: 'National Stadium',
+        status: 'scheduled',
+        kickoffOptions: [
+          { id: 'opt-1', isoTime: '2024-05-05T19:00:00.000Z', votes: 2 },
+        ],
+        acceptedKickoffOptionId: 'opt-1',
+        calendarSynced: false,
+        result: null,
+        notes: undefined,
+        lastUpdated: '2024-04-01T12:00:00.000Z',
+      },
+    ];
+    const communications: CommunicationDigestEntry[] = [
+      {
+        id: 'comm-3',
+        sender: 'Coach',
+        message: 'Travel plans confirmed',
+        date: '2024-05-01T09:00:00.000Z',
+      },
+    ];
+
+    let renderer: TestRenderer.ReactTestRenderer;
+    TestRenderer.act(() => {
+      renderer = TestRenderer.create(
+        <TeamCard
+          team={team}
+          onRemove={() => {}}
+          onManage={() => {}}
+          record={{ wins: 3, draws: 1, losses: 0 }}
+          nextFixtureLabel="Derby County • Sun"
+          nextFixtures={fixtures}
+          communications={communications}
+        />,
+      );
+    });
+
+    const textContent = collectTextContent(renderer!.toJSON());
+    assert.ok(textContent.some((value) => typeof value === 'string' && value.includes('Derby County')));
+    assert.ok(textContent.includes('National Stadium'));
+    assert.ok(textContent.includes('Travel plans confirmed'));
+  })();
+};

--- a/football-app/src/tests/teamScreenData.test.ts
+++ b/football-app/src/tests/teamScreenData.test.ts
@@ -1,0 +1,132 @@
+import { strict as assert } from 'assert';
+import type { Team } from '../store/slices/teamsSlice';
+import type { TeamCommunication } from '../store/slices/communicationsSlice';
+import type { Fixture } from '../store/slices/scheduleSlice';
+import {
+  buildCommunicationDigest,
+  buildScheduleSummary,
+  buildTeamCardsData,
+} from '../screens/teamScreenData';
+
+const createTeam = (id: string, name: string): Team => ({
+  id,
+  name,
+  members: [],
+  settings: {
+    allowJoinRequests: true,
+    notifyMembersOfChanges: true,
+    shareAvailabilityCalendar: false,
+    autoCollectMatchStats: false,
+  },
+});
+
+interface MockState {
+  teams: { teams: Team[] };
+  communications: { communications: TeamCommunication[] };
+  schedule: { fixtures: Fixture[] };
+  [key: string]: unknown;
+}
+
+const createState = (teams: Team[], fixtures: Fixture[], communications: TeamCommunication[]): MockState => ({
+  teams: { teams },
+  communications: { communications },
+  schedule: { fixtures },
+});
+
+export const runTeamScreenDataTests = () => {
+  (function buildScheduleSummaryOrdersFixtures() {
+    const teams = [createTeam('team-1', 'Alpha FC')];
+    const fixtures: Fixture[] = [
+      {
+        id: 'fixture-1',
+        teamId: 'team-1',
+        opponent: 'Beta FC',
+        location: 'City Stadium',
+        status: 'scheduled',
+        kickoffOptions: [
+          { id: 'option-1', isoTime: '2024-05-03T10:00:00.000Z', votes: 5 },
+          { id: 'option-2', isoTime: '2024-05-02T10:00:00.000Z', votes: 3 },
+        ],
+        acceptedKickoffOptionId: null,
+        calendarSynced: false,
+        result: null,
+        notes: undefined,
+        lastUpdated: '2024-04-01T12:00:00.000Z',
+      },
+      {
+        id: 'fixture-2',
+        teamId: 'team-1',
+        opponent: 'Gamma FC',
+        location: 'Away Ground',
+        status: 'completed',
+        kickoffOptions: [
+          { id: 'option-3', isoTime: '2024-04-01T10:00:00.000Z', votes: 5 },
+        ],
+        acceptedKickoffOptionId: 'option-3',
+        calendarSynced: false,
+        result: 'win',
+        notes: undefined,
+        lastUpdated: '2024-04-01T12:00:00.000Z',
+      },
+    ];
+    const state = createState(teams, fixtures, []);
+
+    const summary = buildScheduleSummary(state as any, teams);
+    assert.equal(summary['team-1'].nextFixtures.length, 1);
+    assert.equal(summary['team-1'].nextFixtures[0].id, 'fixture-1');
+    assert.ok(summary['team-1'].nextFixtureLabel?.includes('Beta FC'));
+    assert.deepEqual(summary['team-1'].record, { wins: 1, draws: 0, losses: 0 });
+  })();
+
+  (function buildCommunicationDigestReturnsLatestEntries() {
+    const teams = [createTeam('team-1', 'Alpha FC')];
+    const communications: TeamCommunication[] = [
+      {
+        id: 'comm-1',
+        teamId: 'team-1',
+        title: 'Match recap',
+        body: 'Great game!',
+        status: 'sent',
+        createdAt: '2024-04-02T10:00:00.000Z',
+        scheduledFor: null,
+      },
+      {
+        id: 'comm-2',
+        teamId: 'team-1',
+        title: 'Training reminder',
+        body: 'See you tomorrow',
+        status: 'scheduled',
+        createdAt: '2024-04-01T10:00:00.000Z',
+        scheduledFor: '2024-04-03T10:00:00.000Z',
+      },
+    ];
+    const state = createState(teams, [], communications);
+
+    const digest = buildCommunicationDigest(state as any, teams);
+    assert.equal(digest['team-1'].length, 2);
+    assert.equal(digest['team-1'][0].id, 'comm-1');
+    assert.equal(digest['team-1'][1].date, '2024-04-03T10:00:00.000Z');
+  })();
+
+  (function buildTeamCardsDataMergesSummaries() {
+    const teams = [createTeam('team-1', 'Alpha FC'), createTeam('team-2', 'Bravo FC')];
+    const scheduleSummary = {
+      'team-1': {
+        record: { wins: 1, draws: 0, losses: 0 },
+        nextFixtureLabel: 'Next opponent',
+        nextFixtures: [],
+      },
+    };
+    const communicationDigest = {
+      'team-2': [
+        { id: 'comm', sender: 'Coach', message: 'Hi', date: '2024-04-01T00:00:00.000Z' },
+      ],
+    };
+
+    const cards = buildTeamCardsData(teams, scheduleSummary as any, communicationDigest as any);
+    assert.equal(cards.length, 2);
+    assert.equal(cards[0].record?.wins, 1);
+    assert.equal(cards[1].communications.length, 1);
+    assert.deepEqual(cards[0].communications, []);
+  })();
+};


### PR DESCRIPTION
## Summary
- extract shared formatting helpers for team fixtures and communications and surface empty states in TeamCard
- add pure data builders for TeamScreen to assemble fixture and communication summaries
- expand the custom test runner with TypeScript support, React Native stubs, and new unit tests covering formatting and card rendering

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68e9be5f780483328eddb3498471b069